### PR TITLE
Gnb 공통 컴포넌트 생성

### DIFF
--- a/src/components/common/Gnb.jsx
+++ b/src/components/common/Gnb.jsx
@@ -1,0 +1,74 @@
+import React from 'react';
+import { Link } from 'react-router-dom';
+import styled from 'styled-components';
+
+import Icon from '@/assets/RollingIcon.svg';
+
+const Styled = {
+  Container: styled.nav`
+    display: flex;
+    width: 100vw;
+    align-items: center;
+    padding: 0 max(2.4rem, calc((100vw - 120rem) / 2));
+    position: fixed;
+    top: 0;
+    left: 0;
+    z-index: 1000;
+    background: ${({ theme }) => theme.color.white};
+  `,
+  GnbContainer: styled.div`
+    display: flex;
+    width: 100%;
+    padding: 1.1rem 0;
+    justify-content: space-between;
+  `,
+  LogoFrame: styled(Link)`
+    display: flex;
+    align-items: center;
+    gap: 0.8rem;
+    cursor: pointer;
+    text-decoration: none;
+    .logoName {
+      color: #4a494f;
+      text-align: center;
+      font-family: Poppins;
+      font-size: 2rem;
+      font-style: normal;
+      font-weight: 700;
+      line-height: normal;
+    }
+  `,
+  MakeRollingButton: styled(Link)`
+    padding: 0.8rem 1.6rem;
+    border-radius: 0.6rem;
+    border: ${({ theme }) => theme.border.gr1};
+    background: ${({ theme }) => theme.color.white};
+    color: #181818;
+    text-align: center;
+    font-family: Pretendard;
+    font-size: 1.6rem;
+    font-style: normal;
+    font-weight: 700;
+    line-height: 2.6rem;
+    letter-spacing: -0.02rem;
+    text-decoration: none;
+  `,
+};
+
+function Gnb() {
+  return (
+    <Styled.Container>
+      <Styled.GnbContainer>
+        <Styled.LogoFrame to="/">
+          <img src={Icon} alt="Logo" />
+          <span className="logoName">Rolling</span>
+        </Styled.LogoFrame>
+        <Styled.MakeRollingButton to="/post">
+          롤링 페이퍼 만들기
+        </Styled.MakeRollingButton>
+      </Styled.GnbContainer>
+    </Styled.Container>
+  );
+}
+
+export default Gnb;


### PR DESCRIPTION
## 📌 주요 사항
- [x] 로고' 버튼을 클릭하면 / 페이지로 이동합니다. 
- [x] '롤링 페이퍼 만들기' 버튼을 클릭하면 /post 페이지로 이동합니다.
- [x] Tablet에서 상단 네비게이션은 좌우 여백은 24px로 고정하고 '로고'와 '롤링 페이퍼 만들기' 버튼의 간격이 줄어들거나 커집니다.

## 📷 스크린샷
전체화면일때
<br>
![gnb완성](https://github.com/sihyonn/sprint-part2-rollingProject/assets/151784621/df557246-2f0f-456b-b394-cf433c8d7e2a)
<br>
축소화면일때
<br>
![gnb화면 줄였을시](https://github.com/sihyonn/sprint-part2-rollingProject/assets/151784621/07447003-d60d-4913-a261-7e528e4af049)
<br>
fixed구현
<br>
![gnb fixed 확인](https://github.com/sihyonn/sprint-part2-rollingProject/assets/151784621/54345b3a-fb7a-4ad1-b3bd-ef09b211b2a7)

gnb바 아래 내용은 그냥 임시로 만든겁니다! 


## 💬 리뷰 시 요구사항![선택]
특별히 봐줬으면 하는 부분이 있다면 작성해주세요! 없다면 pass~



## #️⃣ 연관 이슈번호
ex) #이슈번호
close #1 