### PR TITLE
Feat: 구모양 아이콘 버튼 추가

### DIFF
--- a/src/components/common/IconButton.jsx
+++ b/src/components/common/IconButton.jsx
@@ -1,8 +1,9 @@
 import React from 'react';
 import { useState } from 'react';
 import styled from 'styled-components';
-import check from '@/assets/check.svg';
-import plus from '@/assets/plus.svg';
+import { BUTTON_STATUS } from '@/constants/BUTTON_STATUS';
+import check from '@/assets/checkIcon.svg';
+import plus from '@/assets/plusIcon.svg';
 
 const Styled = {
   BackGround: styled.div`
@@ -31,11 +32,10 @@ const Styled = {
 
 function IconButton({ status, shape }) {
   const [buttonStatus, setButtonStatus] = useState('Enabled');
-  const handleMouseEnter = () => setButtonStatus('Hover');
-  const handleMouseLeave = () => setButtonStatus('Enabled');
-  const handleMouseDown = () => setButtonStatus('Pressed');
-  const handleFocus = () => setButtonStatus('Focus');
-  const handleBlur = () => setButtonStatus('Enabled');
+
+  const handleButtonStateChange = (newStatus) => {
+    setButtonStatus(newStatus);
+  };
 
   const imagePath = shape === 'check' ? check : plus;
 
@@ -44,11 +44,11 @@ function IconButton({ status, shape }) {
   return (
     <Styled.BackGround
       status={finalButtonStatus}
-      onMouseEnter={handleMouseEnter}
-      onMouseLeave={handleMouseLeave}
-      onMouseDown={handleMouseDown}
-      onFocus={handleFocus}
-      onBlur={handleBlur}
+      onMouseEnter={() => handleButtonStateChange(BUTTON_STATUS.Hover)}
+      onMouseLeave={() => handleButtonStateChange(BUTTON_STATUS.Enabled)}
+      onMouseDown={() => handleButtonStateChange(BUTTON_STATUS.Pressed)}
+      onFocus={() => handleButtonStateChange(BUTTON_STATUS.Focus)}
+      onBlur={() => handleButtonStateChange(BUTTON_STATUS.Enabled)}
     >
       <img src={imagePath} alt="IconButton" />
     </Styled.BackGround>

--- a/src/components/common/IconButton.jsx
+++ b/src/components/common/IconButton.jsx
@@ -1,0 +1,57 @@
+import React from 'react';
+import { useState } from 'react';
+import styled from 'styled-components';
+import check from '@/assets/check.svg';
+import plus from '@/assets/plus.svg';
+
+const Styled = {
+  BackGround: styled.div`
+    display: flex;
+    padding: 1.6rem;
+    border-radius: 100px;
+    background: ${({ status, theme }) => {
+      switch (status) {
+        case 'Enabled':
+          return theme.color.btnGr;
+        case 'Disabled':
+          return theme.color.mainGr;
+        case 'Hover':
+          return '#4A4A4A';
+        case 'Pressed':
+          return '#3A3A3A';
+        case 'Focus':
+          return '#3A3A3A';
+        default:
+          return theme.color.btnGr;
+      }
+    }};
+    border: ${({ status }) => (status === 'Focus' ? '1px solid #2B2B2B' : '')};
+  `,
+};
+
+function IconButton({ status, shape }) {
+  const [buttonStatus, setButtonStatus] = useState('Enabled');
+  const handleMouseEnter = () => setButtonStatus('Hover');
+  const handleMouseLeave = () => setButtonStatus('Enabled');
+  const handleMouseDown = () => setButtonStatus('Pressed');
+  const handleFocus = () => setButtonStatus('Focus');
+  const handleBlur = () => setButtonStatus('Enabled');
+
+  const imagePath = shape === 'check' ? check : plus;
+
+  const finalButtonStatus = status === 'Disabled' ? 'Disabled' : buttonStatus;
+
+  return (
+    <Styled.BackGround
+      status={finalButtonStatus}
+      onMouseEnter={handleMouseEnter}
+      onMouseLeave={handleMouseLeave}
+      onMouseDown={handleMouseDown}
+      onFocus={handleFocus}
+      onBlur={handleBlur}
+    >
+      <img src={imagePath} alt="IconButton" />
+    </Styled.BackGround>
+  );
+}
+export default IconButton;

--- a/src/constants/BUTTON_STATUS.js
+++ b/src/constants/BUTTON_STATUS.js
@@ -1,0 +1,7 @@
+export const BUTTON_STATUS = {
+  Enabled: 'Enabled',
+  Disabled: 'Disabled',
+  Hover: 'Hover',
+  Pressed: 'Pressed',
+  Focus: 'Focus',
+};


### PR DESCRIPTION
## 📌 주요 사항
-  props로 Iconbutton의 status하고 shape를 받아오며
status 은 Disabled 상황만 지정해주시면 됩니다. 다른 Enabled,Hover,Pressed,Focus 상태는 코드 내에서 hover,focus,press시 알아서 바뀌도록 코드 작성했습니다.
shape 에는 check, plus 두가지가 있습니다


## 📷 스크린샷
![IconButton Icon 시안](https://github.com/sihyonn/sprint-part2-rollingProject/assets/151784621/1fa5727c-36fc-4f48-acaf-dd551863153a)
<br>
결과물 ( 순서대로 Enabled, Disabled,Hover,Pressed,Focus 상태입니다)
<br>
![IconButton](https://github.com/sihyonn/sprint-part2-rollingProject/assets/151784621/7eb87155-8328-40d8-ada8-5c09c9152f2a)

## 💬 리뷰 시 요구사항![선택]
특별히 봐줬으면 하는 부분이 있다면 작성해주세요! 없다면 pass~
- 코드한번 보시고 어떻게 작동하는지 확인 하시고 넘어가주세요

## #️⃣ 연관 이슈번호
ex) #이슈번호
#3 