### PR TITLE
공통 Primary 버튼 구현

### DIFF
--- a/src/components/common/button/Button.jsx
+++ b/src/components/common/button/Button.jsx
@@ -1,0 +1,54 @@
+import React from 'react';
+import { styled } from 'styled-components';
+
+const SIZE = {
+  S: { padding: '0.7rem 1.6rem', width: '12rem' },
+  M: { padding: '1.4rem 2.4rem', width: '28rem' },
+  L: { padding: '1.4rem 2.4rem', width: '72rem' },
+};
+
+const getButtonStyleBySize = (size) => SIZE[size] || SIZE.S;
+
+const Styled = {
+  Button: styled.button`
+    max-width: ${({ size }) => getButtonStyleBySize(size).width};
+    padding: ${({ size }) => getButtonStyleBySize(size).padding};
+    border-radius: ${({ size }) => (size === 'S' ? '0.6rem' : '1.2rem')};
+    background-color: ${({ theme }) => theme.color.mainPu};
+    color: ${({ theme }) => theme.color.white};
+
+    font-size: ${({ size }) => (size === 'S' ? '1.6rem' : '1.8rem')};
+    font-weight: ${({ size }) => (size === 'S' ? '400' : '700')};
+    line-height: ${({ size }) => (size === 'S' ? '2.6rem' : '2.8rem')};
+    white-space: nowrap;
+    text-align: center;
+
+    &:hover {
+      background-color: ${({ theme }) => theme.color.hoverPu};
+    }
+    &:focus {
+      background-color: ${({ theme }) => theme.color.focusPu};
+      border: ${({ theme }) => theme.border.pu3};
+    }
+    &:active {
+      background-color: ${({ theme }) => theme.color.pressePu};
+    }
+  `,
+};
+
+/**
+ * Button - 보라색 배경을 가진 메인 공통 버튼 컴포넌트
+ * @param {string} children 버튼 라벨
+ * @param {string} size 버튼 사이즈(S || M || L)
+ * @param {React.htmlAttributes} htmlButtonProps 기타 버튼 props
+ */
+
+function Button({ children, size = 'S', ...htmlButtonProps }) {
+  return (
+    <Styled.Button type="button" size={size} {...htmlButtonProps}>
+      {children}
+    </Styled.Button>
+  );
+}
+
+export default Button;

--- a/src/components/common/button/Button.jsx
+++ b/src/components/common/button/Button.jsx
@@ -1,25 +1,13 @@
+/* eslint-disable react/prop-types */
 import React from 'react';
 import { styled } from 'styled-components';
-
-const SIZE = {
-  S: { padding: '0.7rem 1.6rem', width: '12rem' },
-  M: { padding: '1.4rem 2.4rem', width: '28rem' },
-  L: { padding: '1.4rem 2.4rem', width: '72rem' },
-};
-
-const getButtonStyleBySize = (size) => SIZE[size] || SIZE.S;
+import { primaryButtonStyles } from '@styles/buttonStyleBySize';
 
 const Styled = {
   Button: styled.button`
-    max-width: ${({ size }) => getButtonStyleBySize(size).width};
-    padding: ${({ size }) => getButtonStyleBySize(size).padding};
-    border-radius: ${({ size }) => (size === 'S' ? '0.6rem' : '1.2rem')};
+    ${({ size }) => primaryButtonStyles[size]}
     background-color: ${({ theme }) => theme.color.mainPu};
     color: ${({ theme }) => theme.color.white};
-
-    font-size: ${({ size }) => (size === 'S' ? '1.6rem' : '1.8rem')};
-    font-weight: ${({ size }) => (size === 'S' ? '400' : '700')};
-    line-height: ${({ size }) => (size === 'S' ? '2.6rem' : '2.8rem')};
     white-space: nowrap;
     text-align: center;
 

--- a/src/pages/Sh.jsx
+++ b/src/pages/Sh.jsx
@@ -1,8 +1,16 @@
 import React from 'react';
+import Button from '@components/common/button/Button';
 
 function Sh() {
-  const s = 'string';
-  return <div>{s}</div>;
+  return (
+    <>
+      <div style={{ display: 'flex', flexDirection: 'column', gap: '1rem' }}>
+        <Button size="S">확인</Button>
+        <Button size="M">구경가기</Button>
+        <Button size="L">삭제하기</Button>
+      </div>
+    </>
+  );
 }
 
 export default Sh;

--- a/src/styles/buttonStyleBySize.js
+++ b/src/styles/buttonStyleBySize.js
@@ -1,0 +1,26 @@
+export const primaryButtonStyles = {
+  S: `
+    padding: 0.7rem 1.6rem; 
+    max-width: 12rem; 
+    border-radius: 0.6rem;
+    font-size: 1.6rem; 
+    font-weight: 400; 
+    line-height: 2.6rem;
+  `,
+  M: `
+    padding: 1.4rem 2.4rem; 
+    max-width: 28rem; 
+    border-radius: 1.2rem;
+    font-size: 1.8rem; 
+    font-weight: 700; 
+    line-height: 2.8rem;
+  `,
+  L: `
+    padding: 1.4rem 2.4rem; 
+    max-width: 72rem; 
+    border-radius: 1.2rem;
+    font-size: 1.8rem; 
+    font-weight: 700; 
+    line-height: 2.8rem;
+  `,
+};


### PR DESCRIPTION
## 📌 주요 사항
- S, M, L 사이즈를 받아서 그에 따라 스타일링 변경되도록 하였습니다.
- 따로 기타 스타일 조정하시고 싶으면 사용하는 곳에서 style={{}}안에 스타일 넘겨주면 그거로 덮일거에요!
- disabled는 피그마시안에 회색이지만 제가 생각하기엔 보라색버튼이 disable 된다고 해서 회색인건 조금 어색해서
클릭시 기능이 작동안하도록 하는게 더 좋을 것 같아서 이번 이슈에선 구현하지 않았습니다.

## 📷 스크린샷
<img width="737" alt="image" src="https://github.com/sihyonn/sprint-part2-rollingProject/assets/124874266/8193aa51-caa8-409f-86b1-1ceec0612d01">

차례대로 S, M, L입니다!


## 💬 리뷰 시 요구사항![선택]
특별히 봐줬으면 하는 부분이 있다면 작성해주세요! 없다면 pass~



## #️⃣ 연관 이슈번호
 close #16 
