### PR TITLE
공통 모달 컴포넌트 구현

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -14,5 +14,6 @@
   </head>
   <body>
     <div id="root"></div>
+    <div id="modal-root"></div>
   </body>
 </html>

--- a/public/index.html
+++ b/public/index.html
@@ -13,7 +13,7 @@
     />
   </head>
   <body>
-    <div id="root"></div>
     <div id="modal-root"></div>
+    <div id="root"></div>
   </body>
 </html>

--- a/src/components/common/modal/BackdropModal.jsx
+++ b/src/components/common/modal/BackdropModal.jsx
@@ -1,0 +1,84 @@
+import React, { useRef } from 'react';
+import { keyframes, styled } from 'styled-components';
+
+import Portal from '@/components/common/modal/Portal';
+
+import useOutsideClick from '@hooks/useOutsideClick';
+import useBodyStyleFixed from '@hooks/useBodyStyleFixed';
+
+const Keyframes = {
+  appear: keyframes`
+  0% {
+      opacity: 0;
+      transform: translateY(100vh) scale(0);
+    }
+  100% {
+    opacity: 1;
+    
+    transform: translateY(0) scale(1);
+  }
+`,
+};
+
+const Styled = {
+  Backdrop: styled.div`
+    width: 100vw;
+    height: 100vh;
+    background: rgba(0, 0, 0, 0.6);
+
+    position: fixed;
+    top: 0;
+
+    display: flex;
+    justify-content: center;
+    align-items: center;
+
+    cursor: pointer;
+  `,
+
+  Container: styled.section`
+    position: relative;
+
+    min-width: 60rem;
+    min-height: 47.6rem;
+    padding: 4rem;
+
+    border-radius: 1.6rem;
+    background-color: ${({ theme }) => theme.color.white};
+    box-shadow: ${({ theme }) => theme.boxShadow.card};
+
+    animation: ${Keyframes.appear} 0.3s 1;
+  `,
+};
+
+/**
+ * BackdropModal - 배경이 반투명인 모달창
+ * @param {React.Dispatch.SetStateAction} setOpen 모달창 열림 상태 변경하는 set 함수
+ * @param {object} modalStyle 모달창 스타일링
+ * @param {React.ReactNode} children 모달창 내부 컴포넌트 및 엘리먼트
+ */
+
+function BackdropModal({ setOpen, modalStyle, children }) {
+  const modalRef = useRef();
+  useBodyStyleFixed();
+
+  useOutsideClick(modalRef, () => {
+    closeModal();
+  });
+
+  const closeModal = () => {
+    setOpen(false);
+  };
+
+  return (
+    <Portal>
+      <Styled.Backdrop>
+        <Styled.Container ref={modalRef} style={modalStyle}>
+          {children}
+        </Styled.Container>
+      </Styled.Backdrop>
+    </Portal>
+  );
+}
+
+export default BackdropModal;

--- a/src/components/common/modal/Portal.jsx
+++ b/src/components/common/modal/Portal.jsx
@@ -1,0 +1,13 @@
+import ReactDOM from 'react-dom';
+
+/**
+ * div#modal-root로 렌더링
+ * @props {React.ReactNode} children
+ */
+
+function Portal({ children }) {
+  const el = document.getElementById('modal-root');
+  return ReactDOM.createPortal(children, el);
+}
+
+export default Portal;

--- a/src/hooks/useBodyStyleFixed.js
+++ b/src/hooks/useBodyStyleFixed.js
@@ -1,0 +1,18 @@
+import { useEffect } from 'react';
+
+function useBodyStyleFixed() {
+  useEffect(() => {
+    document.body.style.cssText = `
+    position: fixed; 
+    top: -${window.scrollY}px;
+    overflow-y: scroll;
+    width: 100%;`;
+    return () => {
+      const scrollY = document.body.style.top;
+      document.body.style.cssText = '';
+      window.scrollTo(0, parseInt(scrollY || '0', 10) * -1);
+    };
+  }, []);
+}
+
+export default useBodyStyleFixed;

--- a/src/hooks/useOutsideClick.js
+++ b/src/hooks/useOutsideClick.js
@@ -1,0 +1,23 @@
+import { useCallback, useEffect } from 'react';
+
+/** ref 외부 클릭시 callback 실행
+ * @param {React.RefObject} ref
+ * @param {function} callback
+ */
+function useOutsideClick(ref, callback) {
+  const handleClick = useCallback(
+    (event) => {
+      if (ref.current && !ref.current.contains(event.target)) {
+        callback?.();
+      }
+    },
+    [ref, callback],
+  );
+
+  useEffect(() => {
+    window.addEventListener('mousedown', handleClick);
+    return () => window.removeEventListener('mousedwon', handleClick);
+  }, [ref, callback, handleClick]);
+}
+
+export default useOutsideClick;


### PR DESCRIPTION
## 📌 주요 사항
- `Portal` 적용했습니다.
- `useOutsideClick` 커스텀 훅을 작성해서 모달 외부 클릭시 닫히는 콜백 수행하도록 하였습니다.
- `useBodyStyleFixed` 커스텀 훅 작성해서 페이지가 스크롤되던 경우 모달창이 열리면 배경 스크롤이 안되도록 고정시켰습니다.
- 공통 모달이기때문에 children으로 모달 안에 들어갈 컴포넌트를 이 BackdropModal로 감싸시면 됩니다.!  

![EB0ABB6D-62BC-4877-980F-D4DF0D99D5AF_4_5005_c](https://github.com/sihyonn/sprint-part2-rollingProject/assets/124874266/363a9a6d-912c-4fe4-b553-b5608372f698)


## 📷 스크린샷

![common-modal](https://github.com/sihyonn/sprint-part2-rollingProject/assets/124874266/342d58fc-4832-4e55-bc11-a2146e95dd49)


## 💬 리뷰 시 요구사항![선택]
특별히 봐줬으면 하는 부분이 있다면 작성해주세요! 없다면 pass~



## #️⃣ 연관 이슈번호
close #22 
