### PR TITLE
Feat:프로필 공통 컴포넌트 구현

### DIFF
--- a/src/components/common/ProfileBadgeCard.jsx
+++ b/src/components/common/ProfileBadgeCard.jsx
@@ -1,0 +1,59 @@
+import React from 'react';
+
+import styled from 'styled-components';
+import { css } from 'styled-components';
+
+const setBackgroundColor = css`
+  background-color: ${(props) => (props.profileImg ? 'transparent' : '#fff')};
+`;
+
+const Styled = {
+  Container: styled.div`
+    display: flex;
+    justify-content: center;
+    align-items: center;
+
+    width: 5.6rem; /* 70% of 8rem */
+    height: 5.6rem; /* 70% of 8rem */
+    padding: 1.68rem;
+
+    border-radius: 100px;
+    border: 1px solid #eee;
+    background-color: ${({ theme }) => theme.color.mainGr};
+    background-image: url(${(props) => props.profileImg || ''});
+    background-position: top;
+    background-size: cover;
+  `,
+  Div: styled.div`
+    display: flex;
+    flex-direction: column;
+    justify-content: center;
+    align-items: center;
+    gap: 0.245rem; /* 70% of 0.35rem */
+  `,
+  Head: styled.div`
+    width: 1.05rem; /* 70% of 1.5rem */
+    height: 1.05rem; /* 70% of 1.5rem */
+    border-radius: 10rem;
+    ${setBackgroundColor}
+  `,
+  Body: styled.div`
+    width: 2.11rem;
+    height: 0.91rem;
+    border-radius: 15.707px 15.707px 3.141px 3.141px;
+    ${setBackgroundColor}
+  `,
+};
+
+function ProfileBadgeCard({ profileImg }) {
+  return (
+    <Styled.Container profileImg={profileImg}>
+      <Styled.Div>
+        <Styled.Head profileImg={profileImg} />
+        <Styled.Body profileImg={profileImg} />
+      </Styled.Div>
+    </Styled.Container>
+  );
+}
+
+export default ProfileBadgeCard;

--- a/src/components/common/ProfileBadgeSelect.jsx
+++ b/src/components/common/ProfileBadgeSelect.jsx
@@ -1,0 +1,59 @@
+import React from 'react';
+
+import styled from 'styled-components';
+import { css } from 'styled-components';
+
+const setBackgroundColor = css`
+  background-color: ${(props) => (props.profileImg ? 'transparent' : '#fff')};
+`;
+
+const Styled = {
+  Container: styled.div`
+    display: flex;
+    justify-content: center;
+    align-items: center;
+
+    width: 8rem;
+    height: 8rem;
+    padding: 2.4rem;
+
+    border-radius: 100px;
+
+    background-color: ${({ theme }) => theme.color.mainGr};
+    background-image: url(${(props) => props.profileImg || ''});
+    background-position: top;
+    background-size: cover;
+  `,
+  Div: styled.div`
+    display: flex;
+    flex-direction: column;
+    justify-content: center;
+    align-items: center;
+    gap: 0.35rem;
+  `,
+  Head: styled.div`
+    width: 1.5rem;
+    height: 1.5rem;
+    border-radius: 10rem;
+    ${setBackgroundColor}
+  `,
+  Body: styled.div`
+    width: 3.02rem;
+    height: 1.3rem;
+    border-radius: 15.707px 15.707px 3.141px 3.141px;
+    ${setBackgroundColor}
+  `,
+};
+
+function ProfileBadgeSelect({ profileImg }) {
+  return (
+    <Styled.Container profileImg={profileImg}>
+      <Styled.Div>
+        <Styled.Head profileImg={profileImg} />
+        <Styled.Body profileImg={profileImg} />
+      </Styled.Div>
+    </Styled.Container>
+  );
+}
+
+export default ProfileBadgeSelect;

--- a/src/pages/Hi.jsx
+++ b/src/pages/Hi.jsx
@@ -1,7 +1,21 @@
+import ProfileBadgeCard from 'src/components/common/ProfileBadgeCard';
+import ProfileBadgeSelect from 'src/components/common/ProfileBadgeSelect';
 import React from 'react';
 
+const mockData = {
+  default: '',
+  img1: 'https://fastly.picsum.photos/id/311/200/200.jpg?hmac=CHiYGYQ3Xpesshw5eYWH7U0Kyl9zMTZLQuRDU4OtyH8',
+};
+
 function Hi() {
-  return <div>Hi</div>;
+  return (
+    <>
+      <ProfileBadgeCard profileImg={mockData.img1} />
+      <ProfileBadgeCard profileImg={mockData.default} />
+      <ProfileBadgeSelect profileImg={mockData.img1} />
+      <ProfileBadgeSelect profileImg={mockData.default} />
+    </>
+  );
 }
 
 export default Hi;

--- a/src/pages/Hi.jsx
+++ b/src/pages/Hi.jsx
@@ -1,19 +1,13 @@
-import ProfileBadgeCard from 'src/components/common/ProfileBadgeCard';
-import ProfileBadgeSelect from 'src/components/common/ProfileBadgeSelect';
 import React from 'react';
-
-const mockData = {
-  default: '',
-  img1: 'https://fastly.picsum.photos/id/311/200/200.jpg?hmac=CHiYGYQ3Xpesshw5eYWH7U0Kyl9zMTZLQuRDU4OtyH8',
-};
+import EmojiBadge from '@components/common/EmojiBadge';
 
 function Hi() {
   return (
     <>
-      <ProfileBadgeCard profileImg={mockData.img1} />
-      <ProfileBadgeCard profileImg={mockData.default} />
-      <ProfileBadgeSelect profileImg={mockData.img1} />
-      <ProfileBadgeSelect profileImg={mockData.default} />
+      <EmojiBadge emoji="" count={14} />
+      <EmojiBadge emoji="😍" count={24} />
+      <EmojiBadge emoji="😍" count={24999} />
+      <EmojiBadge emoji="😍" count={100} />
     </>
   );
 }


### PR DESCRIPTION
## 📌 주요 사항
- prop으로 받는 목데이터에 따라 두개로 나뉘어짐. 
- 메세지 작성할 때 프로필 선택하는 용도로 쓰는 것 -> select라고 마지막에 붙은 컴포넌트
- 카드에 프로필로 올라가는 것 -> Card라고 마지막에 붙은 컴포넌트 ->select에서 모든 수치 70%하향 조정, border 회색 추가
둘 다 prop으로 사진을 받을 수 있다.(prop-profileImg라는 것으로 넣어주면 됨.)

## 📷 스크린샷
<img width="112" alt="image" src="https://github.com/sihyonn/sprint-part2-rollingProject/assets/155143543/7c298191-4715-4162-ae66-5f3e7f8ef22b">



## 💬 리뷰 시 요구사항![선택]
특별히 봐줬으면 하는 부분이 있다면 작성해주세요! 없다면 pass~
힘들지만 .... 수정할 거 있으면 말해보세요!


## #️⃣ 연관 이슈번호
closes #27 
