### PR TITLE
Card컴포넌트 

### DIFF
--- a/src/components/common/Card.jsx
+++ b/src/components/common/Card.jsx
@@ -4,7 +4,7 @@ import styled from 'styled-components';
 import IconButton from '@/components/common/button/IconButton';
 import ProfileBadgeCard from '@/components/common/ProfileBadgeCard';
 import RelationBadge from '@/components/common/RelationBadge';
-import deleteIcon from '@/assets/deletedIcon.svg';
+import OutlinedButton from '@/components/common/button/OutlinedButton';
 
 const Styled = {
   CardContainer: styled.div`
@@ -127,7 +127,7 @@ function Card({ data = mockdata, isEditCard = false, isEditPage = true }) {
             <RelationBadge type={data.relationship} />
           </Styled.NameContainer>
         </Styled.ProfileContainer>
-        {isEditPage && <img src={deleteIcon} alt="delete" />}
+        {isEditPage && <OutlinedButton iconType={'delete'} />}
       </Styled.TopContainer>
       <Styled.Bar />
       <Styled.Message font={data.font}>

--- a/src/components/common/Card.jsx
+++ b/src/components/common/Card.jsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Link } from 'react-router-dom';
+import { useNavigate } from 'react-router-dom';
 import styled from 'styled-components';
 import IconButton from '@/components/common/button/IconButton';
 import ProfileBadgeCard from '@/components/common/ProfileBadgeCard';
@@ -102,11 +102,13 @@ const mockdata = {
 };
 
 function CardAdd({ data, isEditCard }) {
+  const navigate = useNavigate();
   return (
     <Styled.CardContainer isEditCard={isEditCard}>
-      <Link to={`/post/${data.id}/message`}>
-        <IconButton shape="plus" />
-      </Link>
+      <IconButton
+        shape="plus"
+        onClick={() => navigate(`/post/${data.id}/message`)}
+      />
     </Styled.CardContainer>
   );
 }

--- a/src/components/common/Card.jsx
+++ b/src/components/common/Card.jsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { Link } from 'react-router-dom';
 import styled from 'styled-components';
-import IconButton from '@/components/common/IconButton';
+import IconButton from '@/components/common/button/IconButton';
 import ProfileBadgeCard from '@/components/common/ProfileBadgeCard';
 import RelationBadge from '@/components/common/RelationBadge';
 import deleteIcon from '@/assets/deletedIcon.svg';

--- a/src/components/common/Card.jsx
+++ b/src/components/common/Card.jsx
@@ -1,0 +1,136 @@
+import React from 'react';
+import styled from 'styled-components';
+import IconButton from '@/components/common/IconButton';
+import ProfileBadgeCard from '@/components/common/ProfileBadgeCard';
+import RelationBadge from '@/components/common/RelationBadge';
+import deleteIcon from '@/assets/deletedIcon.svg';
+
+const Styled = {
+  CardContainer: styled.div`
+    display: flex;
+    justify-content: center;
+    align-items: ${({ isEditCard }) => (isEditCard ? 'center' : 'start')};
+    flex-direction: column;
+    gap: 1.6rem;
+    width: 38.4rem;
+    height: 28rem;
+    padding: 2.8rem 2.4rem 2.4rem 2.4rem;
+    border-radius: 1.6rem;
+    background: ${({ theme }) => theme.color.white};
+    box-shadow: ${({ theme }) => theme.boxShadow.card};
+    cursor: pointer;
+  `,
+  TopContainer: styled.div`
+    display: flex;
+    align-items: flex-start;
+    justify-content: space-between;
+    width: 100%;
+    img {
+      width: 4rem;
+      height: 4rem;
+    }
+  `,
+  ProfileContainer: styled.div`
+    display: flex;
+    align-items: flex-start;
+    gap: 1.4rem;
+  `,
+
+  NameContainer: styled.div`
+    display: flex;
+    align-items: flex-start;
+    flex-direction: column;
+    gap: 0.6rem;
+
+    span {
+      color: ${({ theme }) => theme.color.black};
+      font-family: Pretendard;
+      font-size: 2rem;
+      font-style: normal;
+      font-weight: 400;
+      line-height: 2.4rem;
+    }
+  `,
+  Bar: styled.div`
+    width: 100%;
+    height: 0.1rem;
+    background: #eee;
+  `,
+  Message: styled.div`
+    width: 100%;
+    height: 10.6rem;
+
+    span {
+      display: -webkit-box;
+      -webkit-box-orient: vertical;
+      -webkit-line-clamp: 4;
+      word-break: break-word;
+      overflow: hidden;
+      color: #4a4a4a;
+      text-overflow: ellipsis;
+      font-family: ${({ font }) => font};
+      font-size: 1.75rem;
+      font-style: normal;
+      font-weight: 400;
+      line-height: 2.8rem;
+      letter-spacing: -0.018rem;
+    }
+  `,
+  Date: styled.span`
+    color: #999;
+    font-family: Pretendard;
+    font-size: 1.2rem;
+    font-style: normal;
+    font-weight: 400;
+    line-height: 1.8rem;
+    letter-spacing: -0.006rem;
+  `,
+};
+
+const mockdata = {
+  id: 28,
+  recipientId: 11,
+  sender: 'test user2',
+  profileImageURL:
+    'https://fastly.picsum.photos/id/311/200/200.jpg?hmac=CHiYGYQ3Xpesshw5eYWH7U0Kyl9zMTZLQuRDU4OtyH8',
+  relationship: '지인',
+  content:
+    'fweawreffewafedwsfseingfwejkoijsdlkwefioujfweolnowejlewfnofweanjowefjlfsadjoawefjkwefjioufwehklfjweohfwenuihfewikhwfeihfewohwefiofhewojfweoljfweonfaewolhjrfweioasdqawdwqadwqwqa',
+  font: '나눔명조',
+  createdAt: '2023-10-31T09:58:47.272896Z',
+};
+
+function CardAdd(isEditCard) {
+  return (
+    <Styled.CardContainer isEditCard={isEditCard}>
+      <IconButton shape="plus" />
+    </Styled.CardContainer>
+  );
+}
+
+function Card({ data = mockdata, isEditCard = false, isEditPage = true }) {
+  // data는 부모 컴포넌트에서 받아오기
+  return isEditCard ? (
+    <CardAdd isEditCard={isEditCard} />
+  ) : (
+    <Styled.CardContainer>
+      <Styled.TopContainer>
+        <Styled.ProfileContainer>
+          <ProfileBadgeCard profileImg={data.profileImageURL} />
+          <Styled.NameContainer>
+            <span>From. {data.sender}</span>
+            <RelationBadge type={data.relationship} />
+          </Styled.NameContainer>
+        </Styled.ProfileContainer>
+        {isEditPage && <img src={deleteIcon} alt="delete" />}
+      </Styled.TopContainer>
+      <Styled.Bar />
+      <Styled.Message font={data.font}>
+        <span>{data.content}</span>
+      </Styled.Message>
+      <Styled.Date>{data.createdAt.split('T')[0]}</Styled.Date>
+    </Styled.CardContainer>
+  );
+}
+
+export default Card;

--- a/src/components/common/Card.jsx
+++ b/src/components/common/Card.jsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import { Link } from 'react-router-dom';
 import styled from 'styled-components';
 import IconButton from '@/components/common/IconButton';
 import ProfileBadgeCard from '@/components/common/ProfileBadgeCard';
@@ -100,10 +101,12 @@ const mockdata = {
   createdAt: '2023-10-31T09:58:47.272896Z',
 };
 
-function CardAdd(isEditCard) {
+function CardAdd({ data, isEditCard }) {
   return (
     <Styled.CardContainer isEditCard={isEditCard}>
-      <IconButton shape="plus" />
+      <Link to={`/post/${data.id}/message`}>
+        <IconButton shape="plus" />
+      </Link>
     </Styled.CardContainer>
   );
 }
@@ -111,7 +114,7 @@ function CardAdd(isEditCard) {
 function Card({ data = mockdata, isEditCard = false, isEditPage = true }) {
   // data는 부모 컴포넌트에서 받아오기
   return isEditCard ? (
-    <CardAdd isEditCard={isEditCard} />
+    <CardAdd data={data} isEditCard={isEditCard} />
   ) : (
     <Styled.CardContainer>
       <Styled.TopContainer>


### PR DESCRIPTION
## 📌 주요 사항
- [x] '+' 버튼을 누르면 /post/{id}/message 로 이동합니다.
-  props로 data isEditCard ( true면 +버튼 있는 카드 false면 메시지 카드) isEditPage(true면 삭제 버튼 있는 카드용 false면 삭제버튼 없음) 받아옵니다.

## 📷 스크린샷
![Card완성본](https://github.com/sihyonn/sprint-part2-rollingProject/assets/151784621/daf5b0c5-0b79-440e-ae9e-44ff51b12c9d)
+버튼 누른 후
![+버튼 누르기 card](https://github.com/sihyonn/sprint-part2-rollingProject/assets/151784621/626da7fe-4b2c-4932-a7d0-b9cf621a8a0e)



## 💬 리뷰 시 요구사항![선택]
요구사항중 '카드'를 누르면 해당 카드가 확대되어 보여집니다 -> 나중에 portal 하고 연계해서 수정!
삭제 버튼은 간단하게 Icon으로 대체하였습니다 시현님 컴포넌트로 대체 예정입니다
추가로 클릭시 카드 삭제 기능도 구현해야합니다

## #️⃣ 연관 이슈번호
ex) #이슈번호
closes#26 