### PR TITLE
Fix: cardsample 및 Option 수정 feat#7

### DIFF
--- a/src/components/common/CardSample.jsx
+++ b/src/components/common/CardSample.jsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import styled from 'styled-components';
-import IconButton from '@/components/common/IconButton';
+import IconButton from '@/components/common/button/IconButton';
 
 const Styled = {
   Card: styled.div`

--- a/src/components/common/CardSample.jsx
+++ b/src/components/common/CardSample.jsx
@@ -5,31 +5,50 @@ import IconButton from '@/components/common/IconButton';
 const Styled = {
   Card: styled.div`
     display: flex;
-    width: 16.8rem;
-    height: 16.8rem;
+    width: ${({ usage }) => (usage == 'option' ? '16.8rem' : '27.5rem')};
+    height: ${({ usage }) => (usage == 'option' ? '16.8rem' : '26rem')};
     border-radius: 1.6rem;
     border: 1px solid rgba(0, 0, 0, 0.08);
-    background: ${({ color, theme }) => {
-      switch (color) {
-        case 'orange':
-          return theme.color.lightOr2;
-        case 'purple':
-          return theme.color.lightPu2;
-        case 'blue':
-          return theme.color.lightBl2;
-        case 'green':
-          return theme.color.lightGn2;
-      }
-    }};
+    background: ${({ color, theme, cardUrl }) =>
+      cardUrl
+        ? `url(${cardUrl}) center/cover`
+        : (() => {
+            switch (color) {
+              case 'orange':
+                return theme.color.lightOr2;
+              case 'purple':
+                return theme.color.lightPu2;
+              case 'blue':
+                return theme.color.lightBl2;
+              case 'green':
+                return theme.color.lightGn2;
+              default:
+                return 'none';
+            }
+          })()};
     align-items: center;
     justify-content: center;
     cursor: pointer;
   `,
 };
 
-function CardSample({ key, color, isChecked, onClick }) {
+function CardSample({
+  key,
+  usage = 'option',
+  color,
+  isChecked,
+  onClick,
+  cardUrl,
+}) {
   return (
-    <Styled.Card key={key} color={color} onClick={onClick}>
+    <Styled.Card
+      key={key}
+      usage={usage}
+      color={color}
+      onClick={onClick}
+      cardUrl={cardUrl}
+      isChecked={isChecked}
+    >
       {isChecked && <IconButton shape="check" />}
     </Styled.Card>
   );

--- a/src/components/common/Option.jsx
+++ b/src/components/common/Option.jsx
@@ -1,6 +1,6 @@
 import React, { useState } from 'react';
 import styled from 'styled-components';
-import CardSample from '@/components/common/Option';
+import CardSample from '@/components/common/CardSample';
 const initialState = {
   orange: false,
   purple: false,
@@ -47,6 +47,7 @@ function Option() {
         {cards.map((card) => (
           <CardSample
             key={card.key}
+            usage="option"
             color={card.color}
             onClick={() => handleCardCheck(card.color)}
             isChecked={checkStatus[card.color]}


### PR DESCRIPTION
## 📌 주요 사항
- props 에 usage 추가하였습니다 usage 에 list를 넣으면 list페이지용이고 option 입력하면 option 용입니다
- 기본용은 option 입니다

## 📷 스크린샷

![option 및 list페이지 쓰는 카드](https://github.com/sihyonn/sprint-part2-rollingProject/assets/151784621/597ac424-0106-4ee5-ac39-ee0572a76253)


## 💬 리뷰 시 요구사항![선택]
특별히 봐줬으면 하는 부분이 있다면 작성해주세요! 없다면 pass~



## #️⃣ 연관 이슈번호
ex) #이슈번호
closes #7 