### PR TITLE
메인, 리스트, 롤링페이퍼 생성, 메세지 작성페이지 반응형 레이아웃 구현

### DIFF
--- a/src/components/common/Gnb.jsx
+++ b/src/components/common/Gnb.jsx
@@ -13,8 +13,9 @@ const Styled = {
     position: fixed;
     top: 0;
     left: 0;
-    z-index: 1000;
+    z-index: 100;
     background: ${({ theme }) => theme.color.white};
+    border-bottom: 1px solid #ededed;
   `,
   GnbContainer: styled.div`
     display: flex;

--- a/src/components/template/Layout.jsx
+++ b/src/components/template/Layout.jsx
@@ -1,7 +1,9 @@
 import React from 'react';
-import { Outlet } from 'react-router-dom';
+import { Outlet, useLocation } from 'react-router-dom';
 import { styled } from 'styled-components';
+
 import Gnb from '@components/common/Gnb';
+import useMobile from '@hooks/useMobile';
 
 const Styled = {
   Container: styled.div`
@@ -9,14 +11,24 @@ const Styled = {
     height: 100vh;
     background-color: ${({ theme }) => theme.color.white};
     padding-top: 6.6rem;
+
+    @media (max-width: 767px) {
+      padding-top: ${({ $invisibelGnb }) => ($invisibelGnb ? '0' : '6.6rem')};
+    }
   `,
 };
 
 function Layout({ children }) {
+  const location = useLocation();
+  const { pathname } = location;
+  const isMobile = useMobile();
+
+  const invisibelGnb = pathname !== '/' && pathname !== '/list' && isMobile;
+
   return (
     <>
-      <Gnb />
-      <Styled.Container>
+      {!invisibelGnb && <Gnb />}
+      <Styled.Container $invisibelGnb={invisibelGnb}>
         <Outlet />
         {children}
       </Styled.Container>

--- a/src/components/template/Layout.jsx
+++ b/src/components/template/Layout.jsx
@@ -1,13 +1,26 @@
 import React from 'react';
 import { Outlet } from 'react-router-dom';
+import { styled } from 'styled-components';
+import Gnb from '@components/common/Gnb';
+
+const Styled = {
+  Container: styled.div`
+    width: 100vw;
+    height: 100vh;
+    background-color: ${({ theme }) => theme.color.white};
+    padding-top: 6.6rem;
+  `,
+};
 
 function Layout({ children }) {
   return (
-    <div>
-      gnb 들어갈 예정!
-      <Outlet />
-      {children}
-    </div>
+    <>
+      <Gnb />
+      <Styled.Container>
+        <Outlet />
+        {children}
+      </Styled.Container>
+    </>
   );
 }
 

--- a/src/components/template/MainLayout.jsx
+++ b/src/components/template/MainLayout.jsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { useLocation } from 'react-router-dom';
+import { Outlet, useLocation } from 'react-router-dom';
 import { styled } from 'styled-components';
 import routes from '@constants/routes';
 
@@ -28,6 +28,7 @@ function MainLayout({ children }) {
 
   return (
     <Styled.Container style={{ paddingTop: calPadding() }}>
+      <Outlet />
       {children}
     </Styled.Container>
   );

--- a/src/components/template/MainLayout.jsx
+++ b/src/components/template/MainLayout.jsx
@@ -1,0 +1,36 @@
+import React from 'react';
+import { useLocation } from 'react-router-dom';
+import { styled } from 'styled-components';
+import routes from '@constants/routes';
+
+const Styled = {
+  Container: styled.div`
+    width: 100%;
+    min-height: 100vh;
+    padding: 0 calc((100vw - 120rem) / 2); //콘텐츠 사이즈 1200
+
+    @media (max-width: 1247px) {
+      padding: 5rem 2.4rem;
+    }
+  `,
+};
+
+/**
+ * MainLayout - 메인, 페이퍼리스트 페이지에 사용되는 레이아웃
+ */
+function MainLayout({ children }) {
+  const location = useLocation();
+  const isListPage = location.pathname === routes.list;
+
+  const calPadding = () => {
+    return isListPage ? '5rem' : '6rem';
+  };
+
+  return (
+    <Styled.Container style={{ paddingTop: calPadding() }}>
+      {children}
+    </Styled.Container>
+  );
+}
+
+export default MainLayout;

--- a/src/components/template/MainLayout.jsx
+++ b/src/components/template/MainLayout.jsx
@@ -8,9 +8,13 @@ const Styled = {
     width: 100%;
     min-height: 100vh;
     padding: 0 calc((100vw - 120rem) / 2); //콘텐츠 사이즈 1200
+    padding-top: ${({ $isListPage }) => ($isListPage ? '5rem' : '6rem')};
 
-    @media (max-width: 1247px) {
-      padding: 5rem 2.4rem;
+    @media (min-width: 768px) and (max-width: 1247px) {
+      padding: 5rem 2.4rem 2.4rem;
+    }
+    @media (max-width: 767px) {
+      padding: 4.2rem 2.4rem 2.4rem;
     }
   `,
 };
@@ -22,12 +26,8 @@ function MainLayout({ children }) {
   const location = useLocation();
   const isListPage = location.pathname === routes.list;
 
-  const calPadding = () => {
-    return isListPage ? '5rem' : '6rem';
-  };
-
   return (
-    <Styled.Container style={{ paddingTop: calPadding() }}>
+    <Styled.Container $isListPage={isListPage}>
       <Outlet />
       {children}
     </Styled.Container>

--- a/src/components/template/PaperCreationLayout.jsx
+++ b/src/components/template/PaperCreationLayout.jsx
@@ -1,0 +1,35 @@
+import React from 'react';
+import { Outlet, useLocation } from 'react-router-dom';
+import { styled } from 'styled-components';
+import routes from '@constants/routes';
+
+const Styled = {
+  Container: styled.div`
+    width: 100%;
+    min-height: 100vh;
+    padding: 0 calc((100vw - 72rem) / 2); //콘텐츠 사이즈 720
+    padding-top: ${({ $isCreatePage }) =>
+      $isCreatePage ? '5.7rem' : '4.7rem'};
+
+    @media (min-width: 768px) and (max-width: 1247px) {
+      padding: 5rem 2.4rem 0;
+    }
+    @media (max-width: 767px) {
+      padding: 5rem 2rem 0;
+    }
+  `,
+};
+
+function PaperCreationLayout({ children }) {
+  const location = useLocation();
+  const isCreatePage = location.pathname === routes.post;
+
+  return (
+    <Styled.Container $isCreatePage={isCreatePage}>
+      <Outlet />
+      {children}
+    </Styled.Container>
+  );
+}
+
+export default PaperCreationLayout;

--- a/src/hooks/useMobile.js
+++ b/src/hooks/useMobile.js
@@ -1,0 +1,23 @@
+import { useState, useEffect } from 'react';
+
+const useMobile = (mobileWidthThreshold = 767) => {
+  const [isMobile, setIsMobile] = useState(
+    window.innerWidth <= mobileWidthThreshold,
+  );
+
+  useEffect(() => {
+    function handleResize() {
+      setIsMobile(window.innerWidth <= mobileWidthThreshold);
+    }
+    window.addEventListener('resize', handleResize);
+    handleResize();
+
+    return () => {
+      window.removeEventListener('resize', handleResize);
+    };
+  }, [mobileWidthThreshold]);
+
+  return isMobile;
+};
+
+export default useMobile;

--- a/src/router.js
+++ b/src/router.js
@@ -18,6 +18,7 @@ import PaperViewerPage from '@pages/PaperViewerPage';
 import CreatePaperPage from '@pages/CreatePaperPage';
 import WirteMessagePage from '@pages/WirteMessagePage';
 import PaperEditPage from '@pages/PaperEditPage';
+import PaperCreationLayout from '@components/template/PaperCreationLayout';
 
 const router = createBrowserRouter([
   /**
@@ -42,17 +43,22 @@ const router = createBrowserRouter([
           },
         ],
       },
+      {
+        element: <PaperCreationLayout />,
+        children: [
+          // 페이퍼 생성(to)
+          {
+            path: routes.post,
+            element: <CreatePaperPage />,
+          },
+          // 메세지 작성(from)
+          {
+            path: `${routes.post}/:id/message`,
+            element: <WirteMessagePage />,
+          },
+        ],
+      },
 
-      // 페이퍼 생성(to)
-      {
-        path: routes.post,
-        element: <CreatePaperPage />,
-      },
-      // 메세지 작성(from)
-      {
-        path: `${routes.post}/:id/message`,
-        element: <WirteMessagePage />,
-      },
       // 생성된 메세지 목록
       {
         path: `${routes.post}/:id`,

--- a/src/router.js
+++ b/src/router.js
@@ -10,6 +10,8 @@ import Yj from '@pages/Yj';
 import Choi from '@pages/Choi';
 
 import Layout from '@components/template/Layout';
+import MainLayout from '@components/template/MainLayout';
+
 import MainPage from '@pages/MainPage';
 import PaperListPage from '@pages/PaperListPage';
 import PaperViewerPage from '@pages/PaperViewerPage';
@@ -25,16 +27,22 @@ const router = createBrowserRouter([
     path: '',
     element: <Layout />,
     children: [
-      // 매인
       {
-        path: routes.home,
-        element: <MainPage />,
+        element: <MainLayout />,
+        children: [
+          // 매인
+          {
+            path: routes.home,
+            element: <MainPage />,
+          },
+          // 페이퍼목록(캐러셀)
+          {
+            path: routes.list,
+            element: <PaperListPage />,
+          },
+        ],
       },
-      // 페이퍼목록(캐러셀)
-      {
-        path: routes.list,
-        element: <PaperListPage />,
-      },
+
       // 페이퍼 생성(to)
       {
         path: routes.post,


### PR DESCRIPTION
## 📌 주요 사항
- 전체 페이지 gnb 적용하였습니다. => `Layout`
- 메인, 리스트 둘 다 너비 반응형 적용했고, 위쪽 패딩은 두 페이지가 조금 차이나서 피그마시안대로 적용해놨습니다. => `MainLayout`
- CreatePaperPage, WriteMessagePage 레이아웃도 적용했습니다 => `PaperCreationLayout`
- 모바일에선 메인, 리스트 빼고 gnb가 안보이길래 커스텀 훅 만들어서 화면사이즈 감지해서 조건부로 렌더했습니다.


## 📷 스크린샷

### [MainPage, PaperListPage] 
<p>
<img src="https://github.com/sihyonn/sprint-part2-rollingProject/assets/124874266/c65e333c-8fdf-43c1-99da-e86fcbb353d7" width="300px"/>

<img src="https://github.com/sihyonn/sprint-part2-rollingProject/assets/124874266/e1a913f8-4e27-444a-9126-9e98bac498e2" width="300px"/>
</p>


--------------------
### [CreatePaperPage, WirteMessagePage] 

<p>
<img src="https://github.com/sihyonn/sprint-part2-rollingProject/assets/124874266/9e456d72-1035-45a1-96bc-4109e7b239c4" width="300px"/>

<img src="https://github.com/sihyonn/sprint-part2-rollingProject/assets/124874266/859dceb8-477d-44b8-99b9-f221efd2e76a" width="300px"/>
</p>



--------------------
  


  ### ⭐️ 수정 ⭐️
  ### 레이아웃들 라우터에 걸어서 페이지단에서 안감싸도 되게 수정했어요!
  ### 그냥 바로 콘텐츠작업하시면 됩니당

  


--------------

## 💬 리뷰 시 요구사항![선택]
제가 구현하는 PaperViewerPage, PaperEditPage까지
이 메인레이아웃을 같이 가져갈까했지만 나중에 혹여 복잡해질까봐 따로 만들도록하겠습니다!
휴! 내거만하면된당🥹


## #️⃣ 연관 이슈번호
close #41 
