### PR TITLE
Feat#40 header 구현

### DIFF
--- a/src/components/common/EmojiCountList.jsx
+++ b/src/components/common/EmojiCountList.jsx
@@ -13,7 +13,7 @@ const Styled = {
 function EmojiCountList({ data }) {
   return (
     <Styled.ListContainer>
-      {data.results.map((items) => (
+      {data.map((items) => (
         <EmojiBadge key={items.id} emoji={items.emoji} count={items.count} />
       ))}
     </Styled.ListContainer>

--- a/src/components/common/Gnb.jsx
+++ b/src/components/common/Gnb.jsx
@@ -7,15 +7,15 @@ import Icon from '@/assets/RollingIcon.svg';
 const Styled = {
   Container: styled.nav`
     display: flex;
-    width: 100vw;
     align-items: center;
-    padding: 0 max(2.4rem, calc((100vw - 120rem) / 2));
     position: fixed;
     top: 0;
     left: 0;
+    width: 100vw;
+    height: 6.6rem;
+    padding: 0 max(2.4rem, calc((100vw - 120rem) / 2));
     z-index: 100;
     background: ${({ theme }) => theme.color.white};
-    border-bottom: 1px solid #ededed;
   `,
   GnbContainer: styled.div`
     display: flex;
@@ -53,6 +53,9 @@ const Styled = {
     line-height: 2.6rem;
     letter-spacing: -0.02rem;
     text-decoration: none;
+    @media (min-width: 768px) and (max-width: 1280px) {
+      display: none;
+    }
   `,
 };
 

--- a/src/components/common/Gnb.jsx
+++ b/src/components/common/Gnb.jsx
@@ -53,9 +53,6 @@ const Styled = {
     line-height: 2.6rem;
     letter-spacing: -0.02rem;
     text-decoration: none;
-    @media (min-width: 768px) and (max-width: 1280px) {
-      display: none;
-    }
   `,
 };
 

--- a/src/components/common/RelationBadge.jsx
+++ b/src/components/common/RelationBadge.jsx
@@ -1,0 +1,40 @@
+import React from 'react';
+import styled, { css } from 'styled-components';
+
+// 이제 badgeColors 대신 아래 getBadgeStyle 함수를 사용
+const getBadgeStyle = (type, theme) => {
+  const styles = {
+    지인: { background: theme.color.lightOr1, color: theme.color.textOr },
+    동료: { background: theme.color.lightPu1, color: theme.color.mainPu },
+    가족: { background: theme.color.lightGn1, color: theme.color.textGn },
+    친구: { background: theme.color.lightBl1, color: theme.color.textBl },
+  };
+  return styles[type] || { background: '#fff', color: '#000' }; // 기본 스타일을 설정
+};
+
+const StyledBadge = styled.div`
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  font-size: 1.4rem;
+  line-height: 2rem;
+  padding: 0 0.8rem;
+  gap: 1rem;
+  width: 4.1rem;
+  height: 2rem;
+  border-radius: 0.4rem;
+  /* props에서 받은 type과 theme를 이용하여 스타일을 적용합니다. */
+  ${({ type, theme }) => {
+    const { background, color } = getBadgeStyle(type, theme);
+    return css`
+      background-color: ${background};
+      color: ${color};
+    `;
+  }}
+`;
+
+function RelationBadge({ type = '지인' }) {
+  return <StyledBadge type={type}>{type}</StyledBadge>;
+}
+
+export default RelationBadge;

--- a/src/components/common/button/OutlinedButton.jsx
+++ b/src/components/common/button/OutlinedButton.jsx
@@ -20,6 +20,11 @@ const Styled = {
     font-size: 1.6rem;
     font-weight: 500;
 
+    @media (max-width: 767px) {
+      padding: ${({ $iconType }) =>
+        $iconType === 'delete' ? '0.8rem' : '0.6rem 0.8rem'};
+    }
+
     &:hover,
     &:focus {
       background-color: #f6f6f6;

--- a/src/components/header/EmojiAddButton.jsx
+++ b/src/components/header/EmojiAddButton.jsx
@@ -41,11 +41,23 @@ const Styled = {
   `,
 };
 
-function EmojiAddButton() {
+function EmojiAddButton({ id }) {
+  //id는 post용
   const [isClicked, setIsClicked] = useState(false);
   const [selectedEmoji, setSelectedEmoji] = useState(null);
+  const [isMobile, setIsMobile] = useState(true);
   const buttonRef = useRef(null);
   const emojiPickerRef = useRef(null);
+  console.log(id);
+  useEffect(() => {
+    const handleResize = () => {
+      setIsMobile(window.innerWidth <= 768);
+    };
+    window.addEventListener('resize', handleResize);
+    return () => {
+      window.removeEventListener('resize', handleResize);
+    };
+  }, []);
 
   const handleButtonClick = () => {
     setIsClicked((prev) => !prev);
@@ -74,13 +86,21 @@ function EmojiAddButton() {
   }, [isClicked, selectedEmoji]);
   return (
     <Styled.Container>
-      <OutlinedButton
-        ref={buttonRef}
-        onClick={handleButtonClick}
-        iconType={'add'}
-      >
-        추가
-      </OutlinedButton>
+      {isMobile ? (
+        <OutlinedButton
+          ref={buttonRef}
+          onClick={handleButtonClick}
+          iconType={'add'}
+        ></OutlinedButton>
+      ) : (
+        <OutlinedButton
+          ref={buttonRef}
+          onClick={handleButtonClick}
+          iconType={'add'}
+        >
+          추가
+        </OutlinedButton>
+      )}
       {isClicked && (
         <Styled.EmojiPickerContainer ref={emojiPickerRef}>
           <Styled.StyledEmojiPicker onEmojiClick={onEmojiClick} />

--- a/src/components/header/EmojiExpand.jsx
+++ b/src/components/header/EmojiExpand.jsx
@@ -17,70 +17,18 @@ const Styled = {
     background: ${({ theme }) => theme.color.white};
     box-shadow: ${({ theme }) => theme.boxShadow.card};
     z-index: 10;
+
+    @media (max-width: 767px) {
+      left: -22rem;
+    }
   `,
 };
 
-const mockdata1 = {
-  count: 4,
-  next: null,
-  previous: '',
-  results: [
-    {
-      id: 34,
-      emoji: '👍',
-      count: 24,
-    },
-    {
-      id: 28,
-      emoji: '😍',
-      count: 16,
-    },
-    {
-      id: 26,
-      emoji: '🎉',
-      count: 10,
-    },
-    {
-      id: 26,
-      emoji: '😂',
-      count: 19,
-    },
-  ],
-};
-
-const mockdata2 = {
-  count: 4,
-  next: null,
-  previous: '',
-  results: [
-    {
-      id: 34,
-      emoji: '👍',
-      count: 70,
-    },
-    {
-      id: 28,
-      emoji: '😍',
-      count: 50,
-    },
-    {
-      id: 26,
-      emoji: '🎉',
-      count: 30,
-    },
-    {
-      id: 26,
-      emoji: '😂',
-      count: 10,
-    },
-  ],
-};
-
-function EmojiExpand() {
+function EmojiExpand({ data1, data2 }) {
   return (
     <Styled.Container>
-      <EmojiCountList data={mockdata1} />
-      <EmojiCountList data={mockdata2} />
+      <EmojiCountList data={data1} />
+      <EmojiCountList data={data2} />
     </Styled.Container>
   );
 }

--- a/src/components/header/EmojiList.jsx
+++ b/src/components/header/EmojiList.jsx
@@ -4,28 +4,6 @@ import styled from 'styled-components';
 import EmojiCountList from '@components/common/EmojiCountList';
 import EmojiExpand from './EmojiExpand';
 import arrowdown from '@/assets/arrowdownIcon.svg';
-const mockdata = {
-  count: 3,
-  next: null,
-  previous: '',
-  results: [
-    {
-      id: 34,
-      emoji: '👍',
-      count: 24,
-    },
-    {
-      id: 28,
-      emoji: '😍',
-      count: 16,
-    },
-    {
-      id: 26,
-      emoji: '🎉',
-      count: 10,
-    },
-  ],
-};
 
 const Styled = {
   Container: styled.div`
@@ -43,7 +21,7 @@ const Styled = {
     align-items: center;
   `,
 };
-function EmojiList() {
+function EmojiList({ EmojiCountData }) {
   const [isClicked, setIsClicked] = useState(false);
   const buttonRef = useRef(null);
   const handleButtonClick = () => {
@@ -61,16 +39,20 @@ function EmojiList() {
       document.removeEventListener('click', handleClickOutside);
     };
   }, [isClicked]);
+
+  const EmojiTopThreeData = EmojiCountData.topReactions.slice(0, 3);
+  const data1 = EmojiCountData.topReactions.slice(0, 4);
+  const data2 = EmojiCountData.topReactions.slice(4, 8);
   return (
     <Styled.Container>
-      <EmojiCountList data={mockdata} />
+      <EmojiCountList data={EmojiTopThreeData} />
       <Styled.EmojiButton
         ref={buttonRef}
         onClick={handleButtonClick}
         type="button"
       >
         <img src={arrowdown} alt="arrowdownIcon" />
-        {isClicked && <EmojiExpand />}
+        {isClicked && <EmojiExpand data1={data1} data2={data2} />}
       </Styled.EmojiButton>
     </Styled.Container>
   );

--- a/src/components/header/EmojiOption.jsx
+++ b/src/components/header/EmojiOption.jsx
@@ -1,21 +1,27 @@
 import React from 'react';
 import styled from 'styled-components';
 import EmojiList from './EmojiList';
-import EmojiAddButton from './EmojiAddButton';
+import EmojiAddButton from './EmojiAddButton'; //team recipient_id 필요
 const Styled = {
   EmojiContainer: styled.div`
     display: flex;
     align-items: flex-start;
     gap: 0.8rem;
+
+    @media (max-width: 767px) {
+      gap: calc(100vw - 40.3rem);
+    }
   `,
 };
 
 //data header에서 api받아오기
-function EmojiOption() {
+function EmojiOption({ EmojiData }) {
+  const { id, topReactions } = EmojiData;
+  const EmojiCountData = { topReactions };
   return (
     <Styled.EmojiContainer>
-      <EmojiList />
-      <EmojiAddButton />
+      <EmojiList EmojiCountData={EmojiCountData} />
+      <EmojiAddButton id={id} />
     </Styled.EmojiContainer>
   );
 }

--- a/src/components/header/EmojiShare.jsx
+++ b/src/components/header/EmojiShare.jsx
@@ -15,10 +15,10 @@ const Styled = {
     background: #eee;
   `,
 };
-function EmojiShare() {
+function EmojiShare({ EmojiData }) {
   return (
     <Styled.Container>
-      <EmojiOption />
+      <EmojiOption EmojiData={EmojiData} />
       <Styled.Bar />
       <SharedButton />
     </Styled.Container>

--- a/src/components/header/Header.jsx
+++ b/src/components/header/Header.jsx
@@ -1,0 +1,193 @@
+import React, { useState, useEffect } from 'react';
+import styled from 'styled-components';
+import ProfileEmojiShare from '@/components/header/ProfileEmojiShare';
+
+const mockdata = {
+  id: 2,
+  name: '강영훈',
+  backgroundColor: 'green',
+  backgroundImageURL: null,
+  createdAt: '2023-10-26T13:19:31.401765Z',
+  messageCount: 10,
+  recentMessages: [
+    {
+      id: 32,
+      recipientId: 2,
+      sender: '김하은',
+      profileImageURL: '',
+      relationship: '가족',
+      content: '열심히 일하는 모습 멋있습니다.',
+      font: 'Pretendard',
+      createdAt: '2023-11-01T08:05:25.399056Z',
+    },
+    {
+      id: 31,
+      recipientId: 2,
+      sender: '이영준',
+      profileImageURL:
+        'https://fastly.picsum.photos/id/311/200/200.jpg?hmac=CHiYGYQ3Xpesshw5eYWH7U0Kyl9zMTZLQuRDU4OtyH8',
+      relationship: '지인',
+      content: '항상 응원합니다',
+      font: 'Noto Sans',
+      createdAt: '2023-11-01T08:04:12.852691Z',
+    },
+    {
+      id: 30,
+      recipientId: 2,
+      sender: '손동욱',
+      profileImageURL: '',
+      relationship: '지인',
+      content: '멋있어요!',
+      font: 'Noto Sans',
+      createdAt: '2023-11-01T08:01:52.605133Z',
+    },
+    {
+      id: 30,
+      recipientId: 2,
+      sender: '손동욱',
+      profileImageURL: '',
+      relationship: '지인',
+      content: '멋있어요!',
+      font: 'Noto Sans',
+      createdAt: '2023-11-01T08:01:52.605133Z',
+    },
+  ],
+  reactionCount: 105,
+  topReactions: [
+    {
+      id: 34,
+      emoji: '👍',
+      count: 50,
+    },
+    {
+      id: 28,
+      emoji: '😍',
+      count: 48,
+    },
+    {
+      id: 26,
+      emoji: '🎉',
+      count: 46,
+    },
+    {
+      id: 26,
+      emoji: '😂',
+      count: 30,
+    },
+    {
+      id: 34,
+      emoji: '👍',
+      count: 24,
+    },
+    {
+      id: 28,
+      emoji: '😍',
+      count: 18,
+    },
+    {
+      id: 26,
+      emoji: '🎉',
+      count: 16,
+    },
+    {
+      id: 26,
+      emoji: '😂',
+      count: 1,
+    },
+  ],
+}; //  'https://rolling-api.vercel.app/{team}/recipients/{id}/'
+
+const Styled = {
+  Container: styled.nav`
+    display: flex;
+    width: 100vw;
+    position: fixed;
+    top: 0;
+    left: 0;
+    padding: 0;
+    z-index: 100;
+    background: ${({ theme }) => theme.color.white};
+    @media (max-width: 767px) {
+      display: inline-block;
+      top: 0;
+    }
+  `,
+  HeaderContainer: styled.div`
+    display: flex;
+    width: 100%;
+    padding: 1.3rem max(2.4rem, calc((100vw - 120rem) / 2));
+    justify-content: space-between;
+
+    @media (max-width: 767px) {
+      padding: 1.2rem 2rem;
+      height: 6.4rem;
+    }
+  `,
+  MobileContainer: styled.div`
+    display: flex;
+    height: 6.4rem;
+    padding: 1rem 2rem;
+    align-items: center;
+  `,
+  CardOwner: styled.span`
+    display: flex;
+    align-items: flex-start;
+    width: 22.7rem;
+    color: #2b2b2b;
+    font-family: Pretendard;
+    font-size: 2.8rem;
+    font-style: normal;
+    font-weight: 700;
+    line-height: 4.2rem;
+    letter-spacing: -0.028rem;
+  `,
+  Bar: styled.div`
+    width: 100%;
+    height: 0.1rem;
+    background: var(--gray-200, #eee);
+  `,
+};
+function Header({ data = mockdata }) {
+  // data는 /list에서 /list{id}로 이동시 페이지에서 보내주기
+  const [isMobile, setIsMobile] = useState(false);
+  const { messageCount, recentMessages } = data;
+  const profileListData = { messageCount, recentMessages };
+  const { id, topReactions } = data;
+  const EmojiData = { id, topReactions };
+  useEffect(() => {
+    const handleResize = () => {
+      setIsMobile(window.innerWidth <= 767);
+    };
+    window.addEventListener('resize', handleResize);
+    return () => {
+      window.removeEventListener('resize', handleResize);
+    };
+  }, []);
+
+  return isMobile ? (
+    <Styled.Container>
+      <Styled.MobileContainer>
+        <Styled.CardOwner>To.{data.name}</Styled.CardOwner>
+      </Styled.MobileContainer>
+      <Styled.Bar />
+      <Styled.HeaderContainer>
+        <ProfileEmojiShare
+          profileData={profileListData}
+          EmojiData={EmojiData}
+        />
+      </Styled.HeaderContainer>
+    </Styled.Container>
+  ) : (
+    <Styled.Container>
+      <Styled.HeaderContainer>
+        <Styled.CardOwner>To.{data.name}</Styled.CardOwner>
+        <ProfileEmojiShare
+          profileData={profileListData}
+          EmojiData={EmojiData}
+        />
+      </Styled.HeaderContainer>
+    </Styled.Container>
+  );
+}
+
+export default Header;

--- a/src/components/header/ProfileBadgeFirst.jsx
+++ b/src/components/header/ProfileBadgeFirst.jsx
@@ -13,7 +13,19 @@ const Styled = {
     justify-content: center;
     align-items: center;
     position: absolute;
-    left: 0;
+    left: ${({ count }) =>
+      (() => {
+        switch (count) {
+          case 1:
+            return '6rem';
+          case 2:
+            return '4rem';
+          case 3:
+            return '2rem';
+          default:
+            return '0';
+        }
+      })()};
     width: 2.8rem;
     height: 2.8rem;
     padding: 0.84rem;
@@ -45,9 +57,9 @@ const Styled = {
   `,
 };
 
-function ProfileBadgeHeader({ profileImg }) {
+function ProfileBadgeHeader({ profileImg, count }) {
   return (
-    <Styled.Container profileImg={profileImg}>
+    <Styled.Container profileImg={profileImg} count={count}>
       <Styled.Div>
         <Styled.Head profileImg={profileImg} />
         <Styled.Body profileImg={profileImg} />

--- a/src/components/header/ProfileBadgeSecond.jsx
+++ b/src/components/header/ProfileBadgeSecond.jsx
@@ -13,7 +13,17 @@ const Styled = {
     justify-content: center;
     align-items: center;
     position: absolute;
-    left: 2rem;
+    left: ${({ count }) =>
+      (() => {
+        switch (count) {
+          case 2:
+            return '6rem';
+          case 3:
+            return '4rem';
+          default:
+            return '2rem';
+        }
+      })()};
     width: 2.8rem;
     height: 2.8rem;
     padding: 0.84rem;
@@ -45,9 +55,9 @@ const Styled = {
   `,
 };
 
-function ProfileBadgeHeader({ profileImg }) {
+function ProfileBadgeHeader({ profileImg, count }) {
   return (
-    <Styled.Container profileImg={profileImg}>
+    <Styled.Container profileImg={profileImg} count={count}>
       <Styled.Div>
         <Styled.Head profileImg={profileImg} />
         <Styled.Body profileImg={profileImg} />

--- a/src/components/header/ProfileBadgeThird.jsx
+++ b/src/components/header/ProfileBadgeThird.jsx
@@ -13,7 +13,15 @@ const Styled = {
     justify-content: center;
     align-items: center;
     position: absolute;
-    left: 4rem;
+    left: ${({ count }) =>
+      (() => {
+        switch (count) {
+          case 3:
+            return '6rem';
+          default:
+            return '4rem';
+        }
+      })()};
     width: 2.8rem;
     height: 2.8rem;
     padding: 0.84rem;
@@ -45,9 +53,9 @@ const Styled = {
   `,
 };
 
-function ProfileBadgeHeader({ profileImg }) {
+function ProfileBadgeHeader({ profileImg, count }) {
   return (
-    <Styled.Container profileImg={profileImg}>
+    <Styled.Container profileImg={profileImg} count={count}>
       <Styled.Div>
         <Styled.Head profileImg={profileImg} />
         <Styled.Body profileImg={profileImg} />

--- a/src/components/header/ProfileEmojiShare.jsx
+++ b/src/components/header/ProfileEmojiShare.jsx
@@ -1,0 +1,32 @@
+import React from 'react';
+import styled from 'styled-components';
+import ProfileList from '@/components/header/ProfileList';
+import EmojiShare from '@/components/header/EmojiShare';
+
+const Styled = {
+  Container: styled.div`
+    display: flex;
+    align-items: center;
+    gap: 2.8rem;
+    @media (max-width: 1280px) {
+      & > *:not(:last-child) {
+        display: none;
+      }
+    }
+  `,
+  Bar: styled.div`
+    width: 0.1rem;
+    height: 2.8rem;
+    background: #eee;
+  `,
+};
+function ProfileEmojiShare({ profileData, EmojiData }) {
+  return (
+    <Styled.Container>
+      <ProfileList data={profileData} />
+      <Styled.Bar />
+      <EmojiShare EmojiData={EmojiData} />
+    </Styled.Container>
+  );
+}
+export default ProfileEmojiShare;

--- a/src/components/header/ProfileList.jsx
+++ b/src/components/header/ProfileList.jsx
@@ -1,47 +1,9 @@
 import React from 'react';
 import styled from 'styled-components';
-import ProfileBadgeCount from '@components/header/ProfileBadgeCount';
+import ProfileBadgeCount from '@/components/header/ProfileBadgeCount';
 import ProfileBadgeFirst from '@components/header/ProfileBadgeFirst';
 import ProfileBadgeSecond from '@components/header/ProfileBadgeSecond';
 import ProfileBadgeThird from '@components/header/ProfileBadgeThird';
-
-const mockdata1 = {
-  messageCount: 9,
-  recentMessages: [
-    {
-      id: 32,
-      recipientId: 2,
-      sender: '김하은',
-      profileImageURL:
-        'https://fastly.picsum.photos/id/311/200/200.jpg?hmac=CHiYGYQ3Xpesshw5eYWH7U0Kyl9zMTZLQuRDU4OtyH8',
-      relationship: '가족',
-      content: '열심히 일하는 모습 멋있습니다.',
-      font: 'Pretendard',
-      createdAt: '2023-11-01T08:05:25.399056Z',
-    },
-    {
-      id: 31,
-      recipientId: 2,
-      sender: '이영준',
-      profileImageURL:
-        'https://fastly.picsum.photos/id/311/200/200.jpg?hmac=CHiYGYQ3Xpesshw5eYWH7U0Kyl9zMTZLQuRDU4OtyH8',
-      relationship: '지인',
-      content: '항상 응원합니다',
-      font: 'Noto Sans',
-      createdAt: '2023-11-01T08:04:12.852691Z',
-    },
-    {
-      id: 30,
-      recipientId: 2,
-      sender: '손동욱',
-      profileImageURL: '',
-      relationship: '지인',
-      content: '멋있어요!',
-      font: 'Noto Sans',
-      createdAt: '2023-11-01T08:01:52.605133Z',
-    },
-  ],
-};
 
 const Styled = {
   Container: styled.div`
@@ -63,20 +25,29 @@ const Styled = {
   `,
 };
 
-function ProfileList({ data = mockdata1 }) {
+function ProfileList({ data }) {
   const isCountBadge = data.messageCount > 3 ? true : false;
   return (
     <Styled.Container>
       <Styled.ListContainer>
-        <ProfileBadgeFirst
-          profileImg={data.recentMessages[0].profileImageURL}
-        />
-        <ProfileBadgeSecond
-          profileImg={data.recentMessages[1].profileImageURL}
-        />
-        <ProfileBadgeThird
-          profileImg={data.recentMessages[2].profileImageURL}
-        />
+        {data.messageCount >= 1 && (
+          <ProfileBadgeFirst
+            profileImg={data.recentMessages[0].profileImageURL}
+            count={data.messageCount}
+          />
+        )}
+        {data.messageCount >= 2 && (
+          <ProfileBadgeSecond
+            profileImg={data.recentMessages[1].profileImageURL}
+            count={data.messageCount}
+          />
+        )}
+        {data.messageCount >= 3 && (
+          <ProfileBadgeThird
+            profileImg={data.recentMessages[2].profileImageURL}
+            count={data.messageCount}
+          />
+        )}
         {isCountBadge && <ProfileBadgeCount count={data.messageCount - 3} />}
       </Styled.ListContainer>
       <Styled.CountInfoContainer>

--- a/src/components/header/SharedOption.jsx
+++ b/src/components/header/SharedOption.jsx
@@ -16,6 +16,10 @@ const Styled = {
     border: ${({ theme }) => theme.border.gr1};
     background: ${({ theme }) => theme.color.white};
     box-shadow: ${({ theme }) => theme.boxShadow.card};
+
+    @media (max-width: 767px) {
+      left: -8rem;
+    }
   `,
   SharedList: styled.div`
     display: flex;

--- a/src/pages/Choi.jsx
+++ b/src/pages/Choi.jsx
@@ -2,14 +2,7 @@ import React from 'react';
 
 import styled from 'styled-components';
 import Header from '@components/header/Header';
-import Gnb from '@components/common/Gnb';
 import CardSample from '@components/common/CardSample';
-
-const Con = styled.div`
-  position: fixed;
-  top: 0;
-  left: 0;
-`;
 
 const Main = styled.div`
   background: #ffe2ad;
@@ -20,20 +13,11 @@ const Main = styled.div`
   justify-content: center;
   display: flex;
 `;
-const Bar = styled.div`
-  width: 100%;
-  height: 0.1rem;
-  background: #ededed;
-`;
 
 function Choi() {
   return (
     <>
-      <Con>
-        <Gnb />
-        <Bar />
-        <Header />
-      </Con>
+      <Header />
       <Main>
         <CardSample color="green" />
       </Main>

--- a/src/pages/Choi.jsx
+++ b/src/pages/Choi.jsx
@@ -1,20 +1,43 @@
 import React from 'react';
-import EmojiShare from '@components/header/EmojiShare';
+
 import styled from 'styled-components';
+import Header from '@components/header/Header';
+import Gnb from '@components/common/Gnb';
+import CardSample from '@components/common/CardSample';
 
 const Con = styled.div`
-  position: relative;
-  margin: 300px auto;
+  position: fixed;
+  top: 0;
+  left: 0;
+`;
+
+const Main = styled.div`
+  background: #ffe2ad;
+  width: 100%;
+  height: 1000px;
+  margin: 0;
   align-items: center;
   justify-content: center;
   display: flex;
 `;
+const Bar = styled.div`
+  width: 100%;
+  height: 0.1rem;
+  background: #ededed;
+`;
 
 function Choi() {
   return (
-    <Con>
-      <EmojiShare />
-    </Con>
+    <>
+      <Con>
+        <Gnb />
+        <Bar />
+        <Header />
+      </Con>
+      <Main>
+        <CardSample color="green" />
+      </Main>
+    </>
   );
 }
 


### PR DESCRIPTION
## 📌 주요 사항
- [x] PC에서 헤더 영역의 너비는 1200px로 고정하고 좌우 여백만 변하다가, 화면의 너비가 1248px보다 줄어들 때 좌우 여백은 24px로 고정하고 'To.OOO' 영역과 '프로필 이미지 OO명이 작성 했어요!' 영역이 가까워집니다.
- 모바일 버전에서는 gnb가 없어져야합니다(list페이지만)
- list 페이지에서 해당하는 카드 주인의 데이터를 받아오면 따로 header내에서 api를 건드릴 필요 없이 데이터가 적용될 수있게 구현했으니 header부분은 따로 api를 건드실 필요 없습니다!

## 📷 스크린샷
pc버전
![Gnb및 header](https://github.com/sihyonn/sprint-part2-rollingProject/assets/151784621/30545889-8025-4b1c-bd6e-b71b4665ea18)
테블릿 버전
![tablet 버전](https://github.com/sihyonn/sprint-part2-rollingProject/assets/151784621/8845845f-7d87-4190-97cc-34e8393ec160)
모바일버전
![header 모바일 버전](https://github.com/sihyonn/sprint-part2-rollingProject/assets/151784621/310de7f5-764c-4771-8eaa-b2dda80650f5)


## 💬 리뷰 시 요구사항![선택]
특별히 봐줬으면 하는 부분이 있다면 작성해주세요! 없다면 pass~
일부러 position: fixed, top:0 left:0 이쪽 스타일링을 뺏습니다
직접 해보니까 이걸 gnb 및 header 컴포넌트에 추가하면 post페이지는 header 컴포넌트와 gnb컴포넌트 사이에 bar가 들어가야하는데 이 bar가 위치가 이상한 곳으로 갑니다
그래서 구현하실때 post페이지 하시는 분은 container로 묶고 그 container 에다가 
 position: fixed, top:0 left:0 이 속성을 추가하시고
다른 페이지 사용하시는 분들은 bar추가 없이 container로 묶고  거기다가 스타일을 추가하시면 됩니다


## #️⃣ 연관 이슈번호
ex) #이슈번호
closes #40 