### PR TITLE
Quill 리팩토링

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -18,6 +18,7 @@
         "@testing-library/user-event": "^13.5.0",
         "axios": "^1.6.7",
         "craco-alias": "^3.0.1",
+        "dompurify": "^3.0.9",
         "emoji-mart": "^5.5.2",
         "emoji-picker-react": "^4.8.0",
         "react": "^18.2.0",
@@ -9026,6 +9027,11 @@
       "funding": {
         "url": "https://github.com/fb55/domhandler?sponsor=1"
       }
+    },
+    "node_modules/dompurify": {
+      "version": "3.0.9",
+      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.0.9.tgz",
+      "integrity": "sha512-uyb4NDIvQ3hRn6NiC+SIFaP4mJ/MdXlvtunaqK9Bn6dD3RuB/1S/gasEjDHD8eiaqdSael2vBv+hOs7Y+jhYOQ=="
     },
     "node_modules/domutils": {
       "version": "2.8.0",

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "@testing-library/user-event": "^13.5.0",
     "axios": "^1.6.7",
     "craco-alias": "^3.0.1",
+    "dompurify": "^3.0.9",
     "emoji-mart": "^5.5.2",
     "emoji-picker-react": "^4.8.0",
     "react": "^18.2.0",

--- a/src/components/common/QuillStrToHtml.jsx
+++ b/src/components/common/QuillStrToHtml.jsx
@@ -1,0 +1,35 @@
+import React, { memo } from 'react';
+import styled from 'styled-components';
+import Dompurify from 'dompurify';
+import '@/styles/quill.strToHtml.css';
+
+const Styled = {
+  Container: styled.div`
+    width: 100%;
+  `,
+};
+
+/**
+ * string을 quill 스타일에 맞게 html로 변환하는 컴포넌트
+ * @param {string} htmlStr 변환할 html 문자열
+ * @param {html.Attributes} containerProps container props
+ */
+
+function QuillStrToHtml({ htmlStr = '', fontStyle, ...containerProps }) {
+  console.log(fontStyle);
+  return (
+    <Styled.Container
+      className={'to-html'}
+      dangerouslySetInnerHTML={{
+        __html: Dompurify.sanitize(htmlStr, {
+          ADD_TAGS: ['iframe'],
+          ADD_ATTR: ['allow', 'allowfullscreen', 'frameborder', 'scrolling'],
+        }),
+      }}
+      style={{ fontFamily: fontStyle }}
+      {...containerProps}
+    />
+  );
+}
+
+export default memo(QuillStrToHtml);

--- a/src/components/rollingPaperViewer/Card.jsx
+++ b/src/components/rollingPaperViewer/Card.jsx
@@ -6,6 +6,7 @@ import RelationBadge from '@/components/common/badge/RelationBadge';
 import OutlinedButton from '@/components/common/button/OutlinedButton';
 import { formatDateToYYYYMMDD } from '@utils/formatDate';
 import DetailCardModal from '@components/rollingPaperViewer/DetailCardModal';
+import QuillStrToHtml from '@components/common/QuillStrToHtml';
 
 const Styled = {
   CardContainer: styled.div`
@@ -60,6 +61,10 @@ const Styled = {
       font-size: 2rem;
       line-height: 2.4rem;
     }
+
+    strong {
+      font-weight: 700;
+    }
   `,
 
   Message: styled.div`
@@ -75,7 +80,7 @@ const Styled = {
       text-overflow: ellipsis;
 
       color: #4a4a4a;
-      font-family: ${({ $font }) => $font};
+      /* font-family: ${({ $font }) => $font}; */
       font-size: 1.75rem;
       line-height: 2.8rem;
       letter-spacing: -0.018rem;
@@ -101,14 +106,16 @@ function Card({ data, isEditPage = false }) {
           <Styled.ProfileContainer>
             <ProfileBadgeCard profileImg={data.profileImageURL} />
             <Styled.NameContainer>
-              <span>From. {data.sender}</span>
+              <span>
+                From. <strong>{data.sender}</strong>
+              </span>
               <RelationBadge type={data.relationship} />
             </Styled.NameContainer>
           </Styled.ProfileContainer>
           {isEditPage && <OutlinedButton iconType={'delete'} />}
         </Styled.TopContainer>
-        <Styled.Message $font={data.font}>
-          <span>{data.content}</span>
+        <Styled.Message>
+          <QuillStrToHtml htmlStr={data.content} fontStyle={data.font} />
         </Styled.Message>
         <Styled.Date>{formatDateToYYYYMMDD(data.createdAt)}</Styled.Date>
       </Styled.CardContainer>

--- a/src/components/rollingPaperViewer/DetailCardModal.jsx
+++ b/src/components/rollingPaperViewer/DetailCardModal.jsx
@@ -1,9 +1,11 @@
 import React from 'react';
-import BackdropModal from '../common/modal/BackdropModal';
 import { styled } from 'styled-components';
+
+import BackdropModal from '@/components/common/modal/BackdropModal';
 import Button from '@/components/common/button/Button';
 import ProfileBadgeCard from '@/components/common/badge/ProfileBadgeCard';
 import RelationBadge from '@/components/common/badge/RelationBadge';
+import QuillStrToHtml from '@components/common/QuillStrToHtml';
 import { formatDateToYYYYMMDD } from '@utils/formatDate';
 
 const Styled = {
@@ -74,7 +76,9 @@ function DetailCardModal({ setOpen, data }) {
         </Styled.From>
         <Styled.Date>{formatDateToYYYYMMDD(data.createdAt)}</Styled.Date>
       </Styled.WriteInfoBox>
-      <Styled.MessageBox>{data.content}</Styled.MessageBox>
+      <Styled.MessageBox>
+        <QuillStrToHtml htmlStr={data.content} fontStyle={data.font} />
+      </Styled.MessageBox>
       <div style={{ display: 'flex', justifyContent: 'center' }}>
         <Button onClick={() => setOpen(false)} style={{ width: '90rem' }}>
           확인

--- a/src/styles/quill.strToHtml.css
+++ b/src/styles/quill.strToHtml.css
@@ -1,0 +1,265 @@
+/* 텍스트 스타일 */
+
+.to-html strong {
+  font-weight: 600;
+}
+
+.to-html em {
+  font-style: italic;
+}
+
+.to-html u {
+  text-decoration: underline;
+}
+
+.to-html s {
+  text-decoration: line-through;
+}
+
+/* text align */
+.to-html .ql-align-center {
+  text-align: center;
+}
+
+.to-html .ql-align-justify {
+  text-align: justify;
+}
+
+.to-html .ql-align-right {
+  text-align: right;
+}
+
+/* ol, li  */
+.to-html .ql-direction-rtl {
+  direction: rtl;
+  text-align: inherit;
+}
+
+.to-html ol,
+.to-html ul {
+  padding-left: 1.5rem;
+  list-style: none;
+}
+
+.to-html ol li:not(.ql-direction-rtl),
+.to-html ul li:not(.ql-direction-rtl) {
+  padding-left: 1.5rem;
+}
+
+.to-html p,
+.to-html ol,
+.to-html ul,
+.to-html pre,
+.to-html blockquote,
+.to-html h1,
+.to-html h2,
+.to-html h3,
+.to-html h4,
+.to-html h5,
+.to-html h6 {
+  margin: 0;
+  padding: 0;
+  counter-reset: list-1 list-2 list-3 list-4 list-5 list-6 list-7 list-8 list-9;
+}
+
+/* li */
+
+.to-html li::before {
+  display: inline-block;
+  white-space: nowrap;
+  width: 1.2em;
+}
+
+.to-html li::before {
+  display: inline-block;
+  white-space: nowrap;
+  width: 1.2em;
+}
+
+.to-html li:not(.ql-direction-rtl)::before {
+  margin-left: -1.5rem;
+  margin-right: 0.3rem;
+  text-align: right;
+}
+
+/* ul li before */
+
+.to-html ul > li::before {
+  content: '•';
+}
+
+/* ol li */
+
+.to-html ol li {
+  counter-reset: list-1 list-2 list-3 list-4 list-5 list-6 list-7 list-8 list-9;
+  counter-increment: list-0;
+}
+
+/* ol li before */
+
+.to-html ol li:not(.ql-direction-rtl)::before {
+  content: counter(list-0, decimal) '. ';
+}
+
+.to-html ol li.ql-indent-1 {
+  counter-reset: list-2 list-3 list-4 list-5 list-6 list-7 list-8 list-9;
+  counter-increment: list-1;
+}
+
+.to-html ol li.ql-indent-1:before {
+  content: counter(list-1, lower-alpha) '. ';
+}
+
+.to-html ol li.ql-indent-2 {
+  counter-reset: list-3 list-4 list-5 list-6 list-7 list-8 list-9;
+  counter-increment: list-2;
+}
+
+.to-html ol li.ql-indent-2:before {
+  content: counter(list-2, lower-roman) '. ';
+}
+
+.to-html ol li.ql-indent-3 {
+  counter-reset: list-4 list-5 list-6 list-7 list-8 list-9;
+  counter-increment: list-3;
+}
+
+.to-html ol li.ql-indent-3:before {
+  content: counter(list-3, decimal) '. ';
+}
+
+.to-html ol li.ql-indent-4 {
+  counter-reset: list-5 list-6 list-7 list-8 list-9;
+  counter-increment: list-4;
+}
+
+.to-html ol li.ql-indent-4:before {
+  content: counter(list-4, lower-alpha) '. ';
+}
+
+.to-html ol li.ql-indent-5 {
+  counter-reset: list-6 list-7 list-8 list-9;
+  counter-increment: list-5;
+}
+
+.to-html ol li.ql-indent-5:before {
+  content: counter(list-5, lower-roman) '. ';
+}
+
+.to-html ol li.ql-indent-6 {
+  counter-reset: list-7 list-8 list-9;
+  counter-increment: list-6;
+}
+
+.to-html ol li.ql-indent-6:before {
+  content: counter(list-6, lower-alpha) '. ';
+}
+
+.to-html ol li.ql-indent-7 {
+  counter-reset: list-8 list-9;
+  counter-increment: list-7;
+}
+
+.to-html ol li.ql-indent-7:before {
+  content: counter(list-7, decimal) '. ';
+}
+
+.to-html ol li.ql-indent-8 {
+  counter-reset: list-9;
+  counter-increment: list-8;
+}
+
+.to-html ol li.ql-indent-8:before {
+  content: counter(list-8, lower-alpha) '. ';
+}
+
+/* tab indent 관련 스타일링 */
+.to-html .ql-indent-1:not(.ql-direction-rtl) {
+  padding-left: 4.5rem;
+}
+
+.to-html .ql-indent-2:not(.ql-direction-rtl) {
+  padding-left: 7.5rem;
+}
+
+.to-html .ql-indent-3:not(.ql-direction-rtl) {
+  padding-left: 10.5rem;
+}
+
+.to-html .ql-indent-4:not(.ql-direction-rtl) {
+  padding-left: 13.5rem;
+}
+
+.to-html .ql-indent-5:not(.ql-direction-rtl) {
+  padding-left: 18.5rem;
+}
+
+.to-html .ql-indent-6:not(.ql-direction-rtl) {
+  padding-left: 21.5rem;
+}
+
+.to-html .ql-indent-7:not(.ql-direction-rtl) {
+  padding-left: 24.5rem;
+}
+
+.to-html .ql-indent-8:not(.ql-direction-rtl) {
+  padding-left: 27.5rem;
+}
+
+/* 폰트 크기 */
+
+.to-html h1,
+.to-html h2,
+.to-html h3,
+.to-html h4,
+.to-html h5,
+.to-html h6 {
+  width: 100%;
+  display: block;
+  overflow: hidden;
+  word-break: break-all;
+}
+.to-html h1 {
+  font-size: 2rem;
+  line-height: 140%;
+}
+
+.to-html h2 {
+  font-size: 1.5rem;
+  line-height: 140%;
+}
+
+.to-html h3 {
+  font-size: 1.15rem;
+  line-height: 140%;
+}
+
+.to-html h4 {
+  font-size: 1rem;
+  line-height: 140%;
+}
+
+.to-html h5 {
+  font-size: 75%;
+  line-height: 140%;
+}
+
+.to-html h6 {
+  font-size: 55%;
+  line-height: 140%;
+}
+
+/* blockquote */
+
+.to-html blockquote {
+  border-left: 4px solid #ff6c6c;
+  margin-bottom: 5px;
+  margin-top: 5px;
+  padding-left: 16px;
+}
+
+/* link */
+.to-html a {
+  text-decoration: underline;
+  color: #06c;
+}


### PR DESCRIPTION
## 📌 주요 사항
- quill 사용해서 메시지 생성 후 카드에서 보여질 때 html태그가 그대로 노출되는 이슈 잡았습니다.
- quill 스타일링을 통해 해당 html의 스타일에 맞게 들어갈 수 있도록 작업했습니다.
- 원래는 자체 스타일 파일에서 폰트 스타일도 관여하지만, 저희는 서버로부터 받아오는 폰트를 사용해야해서
props로 폰트 스타일 보내주고 인라인으로 들어가도록 하여 적용했습니다!

## 📷 스크린샷

![20ACFD30-59C8-41E3-B404-6150C8F45DBD](https://github.com/sihyonn/sprint-part2-rollingProject/assets/124874266/bdf1a30c-bae6-4ce2-a64e-b61d69966dcb)


## 💬 리뷰 시 요구사항![선택]
이거 우리팀만 이렇게 스타일될거같은데..? 



## #️⃣ 연관 이슈번호
이슈를 생성하지 않았습니다!
