### PR TITLE
카드 목록 무한 스크롤 로더 구현

### DIFF
--- a/src/components/rollingPaperViewer/Card.jsx
+++ b/src/components/rollingPaperViewer/Card.jsx
@@ -9,9 +9,6 @@ import DetailCardModal from '@components/rollingPaperViewer/DetailCardModal';
 import QuillStrToHtml from '@components/common/QuillStrToHtml';
 import useDeleteMessageMutation from '@hooks/api/recipientsAPI/useDeleteMessageMutation';
 
-
-
-
 const Styled = {
   CardContainer: styled.div`
     display: flex;

--- a/src/components/rollingPaperViewer/CardMessagesSkeleton.jsx
+++ b/src/components/rollingPaperViewer/CardMessagesSkeleton.jsx
@@ -1,0 +1,120 @@
+import { Shimmer, skeletonStyle } from '@styles/commonStyle';
+import React from 'react';
+import { styled } from 'styled-components';
+
+const Styled = {
+  CardContainer: styled.div`
+    display: flex;
+    justify-content: center;
+    align-items: start;
+    flex-direction: column;
+    gap: 1.6rem;
+
+    height: 100%;
+    padding: 2.8rem 2.4rem 2.4rem;
+    border-radius: 1.6rem;
+    background: ${({ theme }) => theme.color.white};
+    box-shadow: ${({ theme }) => theme.boxShadow.card};
+  `,
+
+  TopContainer: styled.div`
+    width: 100%;
+    padding-bottom: 1.5rem;
+    border-bottom: ${({ theme }) => theme.border.gr5};
+
+    display: flex;
+    align-items: flex-start;
+    justify-content: space-between;
+  `,
+
+  ProfileContainer: styled.div`
+    display: flex;
+    align-items: flex-start;
+    gap: 1.4rem;
+
+    .profileImg {
+      width: 5.6rem;
+      height: 5.6rem;
+      padding: 1.68rem;
+      border-radius: 9999px; //todo 왜안되는지 파악
+      ${skeletonStyle}
+    }
+  `,
+
+  NameContainer: styled.div`
+    display: flex;
+    align-items: flex-start;
+    flex-direction: column;
+    gap: 0.6rem;
+
+    .sender {
+      height: 2.1rem;
+      width: 10rem;
+      ${skeletonStyle}
+    }
+
+    .relation {
+      width: 4.1rem;
+      height: 2rem;
+      border-radius: 0.4rem;
+
+      ${skeletonStyle}
+    }
+  `,
+
+  Message: styled.div`
+    width: 100%;
+    height: 10.6rem;
+
+    .content {
+      width: 100%;
+      height: 2.5rem;
+      margin-bottom: 1rem;
+      overflow: hidden;
+      ${skeletonStyle}
+    }
+  `,
+
+  Date: styled.span`
+    font-size: 1.2rem;
+    line-height: 1.8rem;
+    letter-spacing: -0.006rem;
+    color: #999;
+  `,
+};
+
+function CardMessagesSkeleton() {
+  return (
+    <Styled.CardContainer>
+      <Styled.TopContainer>
+        <Styled.ProfileContainer>
+          <div className="profileImg">
+            <Shimmer />
+          </div>
+          <Styled.NameContainer>
+            <div className="sender">
+              <Shimmer />
+            </div>
+            <div className="relation">
+              <Shimmer />
+            </div>
+          </Styled.NameContainer>
+        </Styled.ProfileContainer>
+      </Styled.TopContainer>
+      <Styled.Message>
+        <div className="content">
+          <Shimmer />
+        </div>
+        <div className="content">
+          <Shimmer />
+        </div>
+        <div className="content">
+          <Shimmer />
+        </div>
+      </Styled.Message>
+      <Styled.Date></Styled.Date>
+    </Styled.CardContainer>
+  );
+}
+
+export default CardMessagesSkeleton;

--- a/src/components/rollingPaperViewer/InfiniteCardMessages.jsx
+++ b/src/components/rollingPaperViewer/InfiniteCardMessages.jsx
@@ -5,6 +5,7 @@ import Card from '@/components/rollingPaperViewer/Card';
 import AddCard from '@/components/rollingPaperViewer/AddCard';
 import useIntersectionObserver from '@hooks/useIntersectionObserver';
 import useInfiniteCardMessagesQuery from '@hooks/api/messagesAPI/useInfiniteCardMessagesQuery';
+import InfiniteCardMessagesLoader from './InfiniteCardMessagesLoader';
 import { GridTemplate } from '@styles/commonStyle';
 
 /**
@@ -34,18 +35,12 @@ function InfiniteCardMessages({ recipientId, isEditPage }) {
           )),
         )}
       </GridTemplate>
-      {/* todo 아래 스켈레톤 로더로 대체하기 */}
-      <div
-        ref={loaderRef}
-        style={
-          isLastPage
-            ? { display: 'none' }
-            : { height: '20px', margin: '10px', backgroundColor: 'lightgray' }
-        }
-        aria-label="Loading more messages"
-      >
-        로딩중이라네
-      </div>
+
+      <InfiniteCardMessagesLoader
+        className="skeleton"
+        loaderRef={loaderRef}
+        style={isLastPage ? { display: 'none' } : { display: 'block' }}
+      />
     </>
   );
 }

--- a/src/components/rollingPaperViewer/InfiniteCardMessagesLoader.jsx
+++ b/src/components/rollingPaperViewer/InfiniteCardMessagesLoader.jsx
@@ -1,0 +1,42 @@
+import React, { useEffect, useRef, useState } from 'react';
+import { GridTemplate } from '@styles/commonStyle';
+import CardMessagesSkeleton from './CardMessagesSkeleton';
+
+const calculateComponentCount = (width) => {
+  if (width < 768) return 2;
+  if (width < 1248) return 4;
+  return 6;
+};
+
+/**
+ * 카드 메시지 무한스크롤 로더
+ */
+
+function InfiniteCardMessagesLoader({ loaderRef, ...props }) {
+  const [windowWidth, setWindowWidth] = useState(window.innerWidth);
+  const componentNumberRef = useRef(calculateComponentCount(window.innerWidth));
+
+  useEffect(() => {
+    const handleResize = () => {
+      setWindowWidth(window.innerWidth);
+    };
+    window.addEventListener('resize', handleResize);
+    return () => {
+      window.removeEventListener('resize', handleResize);
+    };
+  }, []);
+
+  useEffect(() => {
+    componentNumberRef.current = calculateComponentCount(windowWidth);
+  }, [windowWidth]);
+
+  return (
+    <GridTemplate ref={loaderRef} style={{ margin: '3rem 0' }} {...props}>
+      {Array.from({ length: componentNumberRef.current }).map((_, index) => (
+        <CardMessagesSkeleton key={index} />
+      ))}
+    </GridTemplate>
+  );
+}
+
+export default InfiniteCardMessagesLoader;

--- a/src/hooks/api/messagesAPI/useInfiniteCardMessagesQuery.js
+++ b/src/hooks/api/messagesAPI/useInfiniteCardMessagesQuery.js
@@ -1,9 +1,9 @@
-import { useInfiniteQuery } from '@tanstack/react-query';
+import { useSuspenseInfiniteQuery } from '@tanstack/react-query';
 import { API_RECIPIENTS } from '@constants/API';
 import recipientsAPI from '@/api/recipientsAPI';
 
-function useInfiniteCardMessagesQuery(recipientId, limit = 5) {
-  return useInfiniteQuery({
+function useInfiniteCardMessagesQuery(recipientId, limit = 6) {
+  return useSuspenseInfiniteQuery({
     queryKey: [API_RECIPIENTS.RECIPIENTS, recipientId],
     queryFn: async ({ pageParam = 0 }) => {
       const { data } = await recipientsAPI.getMessageToRecipient({

--- a/src/pages/PaperEditPage.jsx
+++ b/src/pages/PaperEditPage.jsx
@@ -1,10 +1,10 @@
 import React from 'react';
-
 import { useNavigate, useParams } from 'react-router-dom';
 import { styled } from 'styled-components';
 
-import InfiniteCardMessages from '@components/rollingPaperViewer/InfiniteCardMessages';
 import Button from '@components/common/button/Button';
+import InfiniteCardMessages from '@components/rollingPaperViewer/InfiniteCardMessages';
+import InfiniteCardMessagesLoader from '@components/rollingPaperViewer/InfiniteCardMessagesLoader';
 import useDeleteRecipientMutation from '@hooks/api/recipientsAPI/useDeleteRecipientMutation';
 import routes from '@constants/routes';
 
@@ -58,7 +58,9 @@ function PaperEditPage() {
         </Button>
       </Styled.ButtonContainer>
 
-      <InfiniteCardMessages recipientId={recipientId} isEditPage={true} />
+      <React.Suspense fallback={<InfiniteCardMessagesLoader />}>
+        <InfiniteCardMessages recipientId={recipientId} isEditPage={true} />
+      </React.Suspense>
     </>
   );
 }

--- a/src/pages/PaperViewerPage.jsx
+++ b/src/pages/PaperViewerPage.jsx
@@ -2,9 +2,10 @@ import React from 'react';
 import { useNavigate, useParams } from 'react-router-dom';
 import { styled } from 'styled-components';
 
-import InfiniteCardMessages from '@components/rollingPaperViewer/InfiniteCardMessages';
 import Button from '@components/common/button/Button';
 import routes from '@constants/routes';
+import InfiniteCardMessages from '@components/rollingPaperViewer/InfiniteCardMessages';
+import InfiniteCardMessagesLoader from '@components/rollingPaperViewer/InfiniteCardMessagesLoader';
 
 const Styled = {
   ButtonContainer: styled.div`
@@ -47,7 +48,9 @@ function PaperViewerPage() {
         </Button>
       </Styled.ButtonContainer>
 
-      <InfiniteCardMessages recipientId={recipientId} />
+      <React.Suspense fallback={<InfiniteCardMessagesLoader />}>
+        <InfiniteCardMessages recipientId={recipientId} />
+      </React.Suspense>
     </>
   );
 }

--- a/src/styles/commonStyle.js
+++ b/src/styles/commonStyle.js
@@ -1,4 +1,4 @@
-import { styled } from 'styled-components';
+import { css, styled } from 'styled-components';
 
 export const GridTemplate = styled.div`
   display: grid;
@@ -16,4 +16,29 @@ export const GridTemplate = styled.div`
     grid-template-columns: repeat(1, 1fr);
     grid-gap: 1.6rem;
   }
+`;
+
+export const Shimmer = styled.div`
+  width: 70%;
+  height: 100%;
+  background-color: #e0e0e0;
+  box-shadow: 0 0 50px 50px #e0e0e0;
+  animation: loading 2s infinite;
+  @keyframes loading {
+    0% {
+      transform: translateX(-50%);
+    }
+    50% {
+      transform: translateX(100%);
+    }
+    100% {
+      transform: translate(200%);
+    }
+  }
+`;
+
+export const skeletonStyle = css`
+  background-color: ${({ theme }) => theme.color.skeleton};
+  overflow: hidden;
+  border-radius: 0.25rem;
 `;

--- a/src/styles/theme.js
+++ b/src/styles/theme.js
@@ -34,6 +34,7 @@ const theme = Object.freeze({
     red: '#DC3A3A',
     surface: '#F6F8FF',
     badgeBg: '#0000008A',
+    skeleton: '#e4e4e4',
   },
 
   border: {


### PR DESCRIPTION
## 📌 주요 사항
- 카드 스켈레톤 생성하였습니다.
- 무한 스크롤 로더 구현하여 각 페이지에 데이터 로딩때 적용되도록 useSuspenseInfiniteQuery로 변경했습니다.

## 📷 스크린샷

![ED7F6751-98B2-4356-8D84-7C028CE5C164](https://github.com/sihyonn/sprint-part2-rollingProject/assets/124874266/bfc401d8-7a4f-4e26-a109-ed3d59243eb3)

로더가 카드 있는부분은 이렇게 잘 붙는데 카드 없는 곳에서 한줄로 길게 이어지는 거같아 스타일링 리팩토링해야될 것 같습니다!

## 💬 리뷰 시 요구사항![선택]
특별히 봐줬으면 하는 부분이 있다면 작성해주세요! 없다면 pass~



## #️⃣ 연관 이슈번호
close#79
