### PR TITLE
카드 메시지 데이터 offset 조정 & 스켈레톤 그리드 싱크 맞추기 완료

### DIFF
--- a/src/components/rollingPaperViewer/CardMessagesSkeleton.jsx
+++ b/src/components/rollingPaperViewer/CardMessagesSkeleton.jsx
@@ -5,8 +5,6 @@ import { styled } from 'styled-components';
 const Styled = {
   CardContainer: styled.div`
     display: flex;
-    justify-content: center;
-    align-items: start;
     flex-direction: column;
     gap: 1.6rem;
 
@@ -23,22 +21,15 @@ const Styled = {
     border-bottom: ${({ theme }) => theme.border.gr5};
 
     display: flex;
-    align-items: flex-start;
-    justify-content: space-between;
+    gap: 1.4rem;
   `,
 
   ProfileContainer: styled.div`
-    display: flex;
-    align-items: flex-start;
-    gap: 1.4rem;
+    width: 5.6rem;
+    height: 5.6rem;
 
-    .profileImg {
-      width: 5.6rem;
-      height: 5.6rem;
-      padding: 1.68rem;
-      border-radius: 9999px; //todo 왜안되는지 파악
-      ${skeletonStyle}
-    }
+    ${skeletonStyle}
+    border-radius: 999px; //todo 왜안되는지 파악
   `,
 
   NameContainer: styled.div`
@@ -63,7 +54,7 @@ const Styled = {
   `,
 
   Message: styled.div`
-    width: 100%;
+    width: 30rem;
     height: 10.6rem;
 
     .content {
@@ -75,11 +66,10 @@ const Styled = {
     }
   `,
 
-  Date: styled.span`
-    font-size: 1.2rem;
-    line-height: 1.8rem;
-    letter-spacing: -0.006rem;
-    color: #999;
+  Date: styled.div`
+    width: 8rem;
+    height: 1.3rem;
+    ${skeletonStyle}
   `,
 };
 
@@ -88,18 +78,17 @@ function CardMessagesSkeleton() {
     <Styled.CardContainer>
       <Styled.TopContainer>
         <Styled.ProfileContainer>
-          <div className="profileImg">
+          <Shimmer />
+        </Styled.ProfileContainer>
+
+        <Styled.NameContainer>
+          <div className="sender">
             <Shimmer />
           </div>
-          <Styled.NameContainer>
-            <div className="sender">
-              <Shimmer />
-            </div>
-            <div className="relation">
-              <Shimmer />
-            </div>
-          </Styled.NameContainer>
-        </Styled.ProfileContainer>
+          <div className="relation">
+            <Shimmer />
+          </div>
+        </Styled.NameContainer>
       </Styled.TopContainer>
       <Styled.Message>
         <div className="content">
@@ -108,11 +97,10 @@ function CardMessagesSkeleton() {
         <div className="content">
           <Shimmer />
         </div>
-        <div className="content">
-          <Shimmer />
-        </div>
       </Styled.Message>
-      <Styled.Date></Styled.Date>
+      <Styled.Date>
+        <Shimmer />
+      </Styled.Date>
     </Styled.CardContainer>
   );
 }

--- a/src/components/rollingPaperViewer/InfiniteCardMessages.jsx
+++ b/src/components/rollingPaperViewer/InfiniteCardMessages.jsx
@@ -39,7 +39,7 @@ function InfiniteCardMessages({ recipientId, isEditPage }) {
       <InfiniteCardMessagesLoader
         className="skeleton"
         loaderRef={loaderRef}
-        style={isLastPage ? { display: 'none' } : { display: 'block' }}
+        style={isLastPage ? { display: 'none' } : { marginTop: '2rem' }}
       />
     </>
   );

--- a/src/components/rollingPaperViewer/InfiniteCardMessagesLoader.jsx
+++ b/src/components/rollingPaperViewer/InfiniteCardMessagesLoader.jsx
@@ -31,9 +31,9 @@ function InfiniteCardMessagesLoader({ loaderRef, ...props }) {
   }, [windowWidth]);
 
   return (
-    <GridTemplate ref={loaderRef} style={{ margin: '3rem 0' }} {...props}>
+    <GridTemplate ref={loaderRef} {...props}>
       {Array.from({ length: componentNumberRef.current }).map((_, index) => (
-        <CardMessagesSkeleton key={index} />
+        <CardMessagesSkeleton className="카드" key={index} />
       ))}
     </GridTemplate>
   );

--- a/src/constants/BUTTON_STATUS.js
+++ b/src/constants/BUTTON_STATUS.js
@@ -1,7 +1,7 @@
-export const BUTTON_STATUS = {
+export const BUTTON_STATUS = Object.freeze({
   ENABLED: 'Enabled',
   DISABLED: 'Disabled',
   HOVER: 'Hover',
   PRESSED: 'Pressed',
   FOCUS: 'Focus',
-};
+});

--- a/src/constants/DROPDOWN_DATA.js
+++ b/src/constants/DROPDOWN_DATA.js
@@ -1,7 +1,7 @@
-export const DROPDOWN_DATA = {
+export const DROPDOWN_DATA = Object.freeze({
   FONT: {
     OPTIONS: ['Noto Sans', 'Pretendard', '나눔명조', '나눔손글씨 손편지체'],
     DEFAULT: 'Noto Sans',
   },
   RELATIONSHIP: { OPTIONS: ['친구', '지인', '동료', '가족'], DEFAULT: '지인' },
-};
+});

--- a/src/constants/PLACEHOLDER.js
+++ b/src/constants/PLACEHOLDER.js
@@ -1,4 +1,4 @@
-export const PLACEHOLDER = {
+export const PLACEHOLDER = Object.freeze({
   TO: '받는 사람 이름을 입력해 주세요.',
   FROM: '이름을 입력해 주세요.',
-};
+});

--- a/src/hooks/api/messagesAPI/useInfiniteCardMessagesQuery.js
+++ b/src/hooks/api/messagesAPI/useInfiniteCardMessagesQuery.js
@@ -25,7 +25,7 @@ function useInfiniteCardMessagesQuery(recipientId, isEditPage, limit = 6) {
       }
 
       const isFirstPage = allPages.length === 1 && !isEditPage;
-      const nextPage = isFirstPage ? initialLimit : allPages.length * limit;
+      const nextPage = isFirstPage ? initialLimit : allPages.length * limit - 1;
 
       if (lastPage?.count <= nextPage) {
         return undefined;

--- a/src/hooks/api/messagesAPI/useInfiniteCardMessagesQuery.js
+++ b/src/hooks/api/messagesAPI/useInfiniteCardMessagesQuery.js
@@ -2,6 +2,16 @@ import { useSuspenseInfiniteQuery } from '@tanstack/react-query';
 import { API_RECIPIENTS } from '@constants/API';
 import recipientsAPI from '@/api/recipientsAPI';
 
+/**
+ * useInfiniteCardMessagesQuery
+ * 무한 스크롤 카드 메시지 쿼리를 위한 리액트쿼리 커스텀 훅
+ * 첫 페이지의 데이터는 AddCard 자리를 제외하고 넣어주기 위해 limit에 차이 적용
+ *
+ * @param {string} recipientId 롤링페이퍼 대상 id
+ * @param {boolean} isEditPage 편집페이지 여부
+ * @param {number} [limit = 6] 한 페이지에 로드할 메시지 수
+ */
+
 function useInfiniteCardMessagesQuery(recipientId, isEditPage, limit = 6) {
   const initialLimit = isEditPage ? limit : limit - 1;
 

--- a/src/styles/commonStyle.js
+++ b/src/styles/commonStyle.js
@@ -40,7 +40,7 @@ export const Shimmer = styled.div`
 export const skeletonStyle = css`
   background-color: ${({ theme }) => theme.color.skeleton};
   overflow: hidden;
-  border-radius: 0.25rem;
+  border-radius: 0.4rem;
 `;
 
 export const mapColorToTheme = (color, theme) => {


### PR DESCRIPTION
## 📌 주요 사항
- 상수에 Object.freeze 처리 안 되었던 부분들 감싸주었습니다.
- 카드 데이터 offset 동적으로 조정해서
   - PaperViewerPage의 경우 첫 데이터만 5, 나머지 6, 6, 6, ... 불러오도록 하였고
   - PaperEditPage의 경우 6, 6, 6, ... 불러오도록 하였습니다.
- 기존 스켈레톤 UI가 grid가 안먹히는 이슈로 한줄을 다 차지해서 실제 렌더링 카드메시지 UI와 싱크가 맞지 않았는데,
   상위 컴포넌트에서 style display block에 의해 하위에서 그리드가 미적용 되는 문제를 파악해서 처리하였습니다! 

## 📷 스크린샷

![skeleton-refactoring](https://github.com/sihyonn/sprint-part2-rollingProject/assets/124874266/ebf91343-0496-4611-8f86-c260cce1e0cf)


## 💬 리뷰 시 요구사항![선택]
이제 마음이 너무 편해요... 다 세세히 들여다보면 해결될 버그였네용..ㅎㅎ



## #️⃣ 연관 이슈번호
close #98 
